### PR TITLE
Fix exception on EmbeddedProcessor

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/embedder/YoutubeEmbedder.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/embedder/YoutubeEmbedder.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -66,6 +67,14 @@ public class YoutubeEmbedder extends AbstractEmbedder {
       Matcher matcher = pattern.matcher(url);
       if (matcher.find()) {
         feedsURL = schemeEndpointMap.get(pattern);
+        try {
+          String currentDomain = CommonsUtils.getCurrentDomain();
+          if (currentDomain.startsWith("https")) {
+            scheme = "https";
+          }
+        } catch (Exception e) {
+          LOG.info("Cannot get scheme from Portal Request Context", e);
+        }
       }
     }
     if (feedsURL == null) {

--- a/commons-component-common/src/main/java/org/exoplatform/commons/embedder/YoutubeEmbedder.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/embedder/YoutubeEmbedder.java
@@ -66,14 +66,6 @@ public class YoutubeEmbedder extends AbstractEmbedder {
       Matcher matcher = pattern.matcher(url);
       if (matcher.find()) {
         feedsURL = schemeEndpointMap.get(pattern);
-        try {
-          PortalRequestContext portalRequestContext = Util.getPortalRequestContext();
-          if (portalRequestContext != null && portalRequestContext.getRequest() != null) {
-            scheme = portalRequestContext.getRequest().getScheme();
-          }
-        } catch (Exception e) {
-          LOG.info("Cannot get scheme from Portal Request Context", e);
-        }
       }
     }
     if (feedsURL == null) {


### PR DESCRIPTION
I remove the `portalRequestContext` because `Util.getPortalRequestContext()`  all time thrown null pointer exception, so we don't need the variable