### PR TITLE
Fix/PLF-8773: Add option configuration to active browser spellchecker in CKEditor

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
@@ -49,7 +49,7 @@ CKEDITOR.editorConfig = function( config ) {
 
     config.uploadUrl = eXo.env.server.context + '/upload?action=upload&uploadId=';
 
-    //Active spellCheker
+    // Enable the browser native spell checker
     config.disableNativeSpellChecker = false;
 
     // Set the most common block elements.

--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
@@ -49,6 +49,9 @@ CKEDITOR.editorConfig = function( config ) {
 
     config.uploadUrl = eXo.env.server.context + '/upload?action=upload&uploadId=';
 
+    //Active spellCheker
+    config.disableNativeSpellChecker = false;
+
     // Set the most common block elements.
     config.format_tags = 'p;h1;h2;h3;pre';
 


### PR DESCRIPTION
By default, native browser spell check functionality is disabled in the editor. Use this configuration option to enable it :

config.disableNativeSpellChecker = false;