### PR TITLE
MAINT-26695: No result for searched files

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
@@ -194,9 +194,6 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
       List<String> queryParts = Arrays.asList(query.split(" "));
       queryParts = queryParts.stream().map(queryPart -> {
         queryPart = this.escapeReservedCharacters(queryPart);
-        if (queryPart.length() > 5) {
-          queryPart = queryPart + "~1"; // fuzzy search on big words
-        }
         return queryPart;
       }).collect(Collectors.toList());
       String escapedQueryWithAndOperator = StringUtils.join(queryParts, " AND ");


### PR DESCRIPTION
The problem is that when we have a file with composed title (ex: test-pdf.pdf), we cannot search it by the full title.