### PR TITLE
MAINT-26695: No result for searched files

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
@@ -191,9 +191,9 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
     esQuery.append("     \"query\": {\n");
     esQuery.append("        \"bool\" : {\n");
     if (StringUtils.isNotBlank(query)) {
-      List<String> queryParts = Arrays.asList(query.split(" "));
+      List<String> queryParts = Arrays.asList(query.split("[\\+\\-=\\&\\|><\\!\\(\\)\\{\\}\\[\\]\\^\"\\*\\?:\\/ @]+"));
       queryParts = queryParts.stream().map(queryPart -> {
-        queryPart = "\\\"" +  this.escapeReservedCharacters(queryPart) + "\\\"";
+        queryPart = this.escapeReservedCharacters(queryPart);
         if (queryPart.length() > 5) {
           queryPart = queryPart + "~1"; // fuzzy search on big words
         }

--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
@@ -193,7 +193,7 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
     if (StringUtils.isNotBlank(query)) {
       List<String> queryParts = Arrays.asList(query.split(" "));
       queryParts = queryParts.stream().map(queryPart -> {
-        queryPart = this.escapeReservedCharacters(queryPart);
+        queryPart = "\\\"" +  this.escapeReservedCharacters(queryPart) + "\\\"";
         if (queryPart.length() > 5) {
           queryPart = queryPart + "~1"; // fuzzy search on big words
         }


### PR DESCRIPTION
The problem is caused by the special characters in title. To fix this problem, we have to escape these characters and add quotes around the text.

https://discuss.elastic.co/t/elasticsearch-escape-character/163216/1