### PR TITLE
MAINT-2799: Add UpgradeProductService configuration

### DIFF
--- a/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/upgrade-configuration.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/upgrade-configuration.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+               xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+	<component>
+		<type>org.exoplatform.commons.upgrade.UpgradeProductService</type>
+		<init-params>
+			<!-- Proceed to the upgrade if it's first time you run this service -->
+			<value-param>
+				<name>proceedUpgradeWhenFirstRun</name>
+				<value>${commons.upgrade.proceedIfFirstRun:true}</value>
+			</value-param>
+		</init-params>
+	</component>
+</configuration>

--- a/commons-extension-webapp/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -30,4 +30,5 @@
   <import>war:/conf/commons-extension/notification-configuration.xml</import>
   <import>war:/conf/commons-extension/account-setup-configuration.xml</import>
   <import>war:/conf/commons-extension/resource-bundle-configuration.xml</import>
+  <import>war:/conf/commons-extension/upgrade-configuration.xml</import>
 </configuration>


### PR DESCRIPTION
The UpgradeProductService is needed for 6.0 upgrade plugins implem so the configuration should be added