### PR TITLE
Fix JS Error for login page in French

### DIFF
--- a/commons-extension-webapp/src/main/webapp/login/jsp/login.jsp
+++ b/commons-extension-webapp/src/main/webapp/login/jsp/login.jsp
@@ -131,11 +131,11 @@
 
                 <div class="userCredentials">
                   <span class="iconUser"></span>
-                  <input  tabindex="1" id="username" name="username" type="text" placeholder="<%=res.getString("portal.login.Username")%>" onblur="this.placeholder = '<%=res.getString("portal.login.Username.blur")%>'" onfocus="this.placeholder = ''">
+                  <input  tabindex="1" id="username" name="username" type="text" placeholder="<%=res.getString("portal.login.Username")%>">
                 </div>
                 <div class="userCredentials">
                   <span class="iconPswrd"></span>
-                  <input  tabindex="2"  type="password" id="password" name="password" placeholder="<%=res.getString("portal.login.Password")%>" onblur="this.placeholder = '<%=res.getString("portal.login.Password")%>'" onfocus="this.placeholder = ''">
+                  <input  tabindex="2"  type="password" id="password" name="password" placeholder="<%=res.getString("portal.login.Password")%>">
                 </div>
 
                 <div class="rememberContent">


### PR DESCRIPTION
When displaying the login page in French, the placeholder of username field is `Nom d'utilisateur` which uses `'` character in string. So this statement (after JSP compilation):
`onblur="this.placeholder = '<%=res.getString("portal.login.Password")%>'" onfocus="this.placeholder = ''"`
becomes
`onblur="this.placeholder = 'Nom d'utilisateur'" onfocus="this.placeholder = ''"`
which will make a JS error.
In fact, the placeholder is natively managed by browser and shouldn't be modified on user event (as made for other eXo UIs)