### PR TITLE
TASK-36786 Avoid processing asynchronously ES queue before indices initialized

### DIFF
--- a/commons-search/src/test/java/org/exoplatform/commons/search/index/ElasticOperationProcessorTest.java
+++ b/commons-search/src/test/java/org/exoplatform/commons/search/index/ElasticOperationProcessorTest.java
@@ -106,6 +106,7 @@ public class ElasticOperationProcessorTest {
     elasticIndexingOperationProcessor = new ElasticIndexingOperationProcessor(indexingOperationDAO, elasticIndexingClient, elasticContentRequestBuilder, auditTrail, entityManagerService, null, initParams);
     initElasticServiceConnector();
     initElasticContentRequestBuilder();
+    elasticIndexingOperationProcessor.setInitialized(true);
   }
 
   private void initElasticServiceConnector() {


### PR DESCRIPTION
When starting a server while the ES is not yet fully started, or when the initialization of indices phase fails, indices with alias name are created and replaces original aliases. This PR ensures to not process Indexing Queue if the initialization phase doesn't finish properly.