### PR TITLE
MAINT-28629:fix news cke links update

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/simpleLink/dialogs/simpleLink.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/simpleLink/dialogs/simpleLink.js
@@ -38,6 +38,8 @@ CKEDITOR.dialog.add( 'simpleLinkDialog', function( editor ) {
                                 url = "http://" + url;
                             }
                             element.setAttribute("href", url);
+                            element.setAttribute("data-cke-saved-href", url);
+
                         },
                         onLoad : function () {
                             this.getInputElement().$.className = ''; 


### PR DESCRIPTION
This fixes a bug where changing the href/url of a link wouldn't be updated in the HTML returned by editor.getData()

data-cke-saved-href` is an extra attribute created by CKEditor on 'a'  tag , and this carries through into the embed code when you edit a link. 

**Bref : SimpleLink plugin wasn't update the right attribute**