### PR TITLE
Include Commons.properties in predefined resource Bundles

### DIFF
--- a/commons-webui-component/src/main/resources/conf/portal/configuration.xml
+++ b/commons-webui-component/src/main/resources/conf/portal/configuration.xml
@@ -18,6 +18,11 @@
       <type>org.exoplatform.services.resources.impl.BaseResourceBundlePlugin</type>
       <init-params>
         <values-param>
+          <name>init.resources</name>
+          <description>The properties files of the portal , those file will be merged into one ResoruceBundle properties </description>
+          <value>locale.commons.Commons</value>
+        </values-param>
+        <values-param>
           <name>classpath.resources</name>
           <description>The resources that start with the following package name should be load from file system</description>
           <value>locale.commons.Commons</value>


### PR DESCRIPTION
A problem happens sometimes on prod while computing or displaying notifications:
 Can't find resource for bundle org.exoplatform.commons.utils.MapResourceBundle, key TimeConvert.type.HOUR
This fix will ensure to include this resource bundle file in shared Resource Bundles