### PR TITLE
Fix-40168: cKeditor removes empty i tags

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoConfig.js
+++ b/commons-extension-webapp/src/main/webapp/eXoConfig.js
@@ -33,6 +33,7 @@ CKEDITOR.editorConfig = function( config ){
 	config.pasteFromWordRemoveStyles = false;
         config.syntaxhighlight_lang = 'java';
 	config.syntaxhighlight_hideControls = true;
+	CKEDITOR.dtd.$removeEmpty['i'] = false;
 
   // style inside the editor
 	config.contentsCss = '/commons-extension/ckeditorCustom/contents.css';


### PR DESCRIPTION
Fix Bug: CkEditor removes Icons of empty i tags