### PR TITLE
Task-40071 Return minimal version of Supported Platform for Mobile App

### DIFF
--- a/commons-component-product/pom.xml
+++ b/commons-component-product/pom.xml
@@ -78,8 +78,53 @@
       <artifactId>bcprov-jdk15</artifactId>
     </dependency>
     <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.identity</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.portal</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.gatein.portal</groupId>
+      <artifactId>exo.portal.component.application-registry</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <!-- This dependency is used for test classes compilation but is erroneously reported as useless by mvn dependency:analyze -->
+    <dependency>
       <groupId>org.exoplatform.commons</groupId>
       <artifactId>commons-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -95,5 +140,21 @@
         </includes>
       </testResource>
     </testResources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <java.naming.factory.initial>org.exoplatform.services.naming.SimpleContextFactory</java.naming.factory.initial>
+            <exo.profiles>hsqldb</exo.profiles>
+            <com.arjuna.ats.arjuna.objectstore.objectStoreDir>${project.build.directory}</com.arjuna.ats.arjuna.objectstore.objectStoreDir>
+            <ObjectStoreEnvironmentBean.objectStoreDir>${project.build.directory}</ObjectStoreEnvironmentBean.objectStoreDir>
+            <gatein.test.tmp.dir>${project.build.directory}</gatein.test.tmp.dir>
+            <gatein.test.output.path>${project.build.directory}</gatein.test.output.path>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/commons-component-product/src/main/java/org/exoplatform/commons/info/PlatformInformationRESTService.java
+++ b/commons-component-product/src/main/java/org/exoplatform/commons/info/PlatformInformationRESTService.java
@@ -45,6 +45,8 @@ public class PlatformInformationRESTService implements ResourceContainer {
 
   public static final java.lang.String ENTERPRISE_EDITION = "enterprise";
 
+  public static final java.lang.String MIN_MOBILE_SUPPORTED_VERSION = "4.3.0+";
+
   private ProductInformations          platformInformations;
 
   private UserACL                      userACL;
@@ -57,14 +59,12 @@ public class PlatformInformationRESTService implements ResourceContainer {
   /**
    * This method return a JSON Object with the platform required informations.
    * 
-   * @param sc securty context of REST Service xecution
    * @return REST response
    */
   @GET
   @Path("/info")
-  @RolesAllowed("administrators")
   @Produces(MediaType.APPLICATION_JSON)
-  public Response getPlatformInformation(@Context SecurityContext sc) {
+  public Response getPlatformInformation() {
     CacheControl cacheControl = new CacheControl();
     cacheControl.setNoCache(true);
     cacheControl.setNoStore(true);
@@ -72,20 +72,25 @@ public class PlatformInformationRESTService implements ResourceContainer {
       String plfProfile = ExoContainer.getProfiles().toString().trim();
       String runningProfile = plfProfile.substring(1, plfProfile.length() - 1);
       JsonPlatformInfo jsonPlatformInfo = new JsonPlatformInfo();
-      jsonPlatformInfo.setPlatformVersion(platformInformations.getVersion());
-      jsonPlatformInfo.setPlatformBuildNumber(platformInformations.getBuildNumber());
-      jsonPlatformInfo.setPlatformRevision(platformInformations.getRevision());
-      jsonPlatformInfo.setIsMobileCompliant(isMobileCompliant().toString());
-      jsonPlatformInfo.setRunningProfile(runningProfile);
-      jsonPlatformInfo.setPlatformEdition(getPlatformEdition());
-      if ((platformInformations.getEdition() != null) && (!platformInformations.getEdition().equals(""))) {
-        jsonPlatformInfo.setDuration(platformInformations.getDuration());
-        jsonPlatformInfo.setDateOfKeyGeneration(platformInformations.getDateOfLicence());
-        jsonPlatformInfo.setNbUsers(platformInformations.getNumberOfUsers());
-        if (userACL.isUserInGroup(userACL.getAdminGroups())) {
+      if (userACL.isUserInGroup(userACL.getAdminGroups())) {
+        jsonPlatformInfo.setPlatformVersion(platformInformations.getVersion());
+        jsonPlatformInfo.setPlatformBuildNumber(platformInformations.getBuildNumber());
+        jsonPlatformInfo.setPlatformRevision(platformInformations.getRevision());
+        jsonPlatformInfo.setIsMobileCompliant(isMobileCompliant().toString());
+        jsonPlatformInfo.setRunningProfile(runningProfile);
+        jsonPlatformInfo.setPlatformEdition(getPlatformEdition());
+        if ((platformInformations.getEdition() != null) && (!platformInformations.getEdition().equals(""))) {
+          jsonPlatformInfo.setDuration(platformInformations.getDuration());
+          jsonPlatformInfo.setDateOfKeyGeneration(platformInformations.getDateOfLicence());
+          jsonPlatformInfo.setNbUsers(platformInformations.getNumberOfUsers());
           jsonPlatformInfo.setProductCode(platformInformations.getProductCode());
           jsonPlatformInfo.setUnlockKey(platformInformations.getProductKey());
         }
+      } else {
+        // Add a compliant version to mobile application
+        // without exposing real version of platform
+        // to anonymous or connected users
+        jsonPlatformInfo.setPlatformVersion(MIN_MOBILE_SUPPORTED_VERSION);
       }
       if (LOG.isDebugEnabled()) {
         LOG.debug("Getting Platform Informations: eXo Platform (v" + platformInformations.getVersion() + " - build "

--- a/commons-component-product/src/test/java/org/exoplatform/commons/info/test/PlatformInformationRESTServiceTEST.java
+++ b/commons-component-product/src/test/java/org/exoplatform/commons/info/test/PlatformInformationRESTServiceTEST.java
@@ -1,0 +1,114 @@
+package org.exoplatform.commons.info.test;
+
+import static org.junit.Assert.assertNotEquals;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.exoplatform.commons.info.PlatformInformationRESTService;
+import org.exoplatform.commons.info.PlatformInformationRESTService.JsonPlatformInfo;
+import org.exoplatform.commons.info.ProductInformations;
+import org.exoplatform.commons.testing.BaseResourceTestCase;
+import org.exoplatform.component.test.*;
+import org.exoplatform.portal.config.UserACL;
+import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.rest.wadl.research.HTTPMethods;
+import org.exoplatform.services.security.*;
+
+@ConfiguredBy(
+  {
+      @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+      @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
+      @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/test-configuration.xml"),
+      @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.commons.component.core-dependencies-configuration.xml"),
+      @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.commons.component.core-configuration.xml"),
+      @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/exo.commons.component.core-local-test-configuration.xml")
+  }
+)
+public class PlatformInformationRESTServiceTEST extends BaseResourceTestCase {
+
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+    endSession();
+  }
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    assertNotNull(getContainer().getComponentInstanceOfType(PlatformInformationRESTService.class));
+    registry(new PlatformInformationRESTService(getService(ProductInformations.class), getService(UserACL.class)));
+  }
+
+  public void testGetPlatformInformationAnonymous() throws Exception { // NOSONAR
+    ContainerResponse response = service(HTTPMethods.GET.toString(), "/platform/info", StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    JsonPlatformInfo jsonPlatformInfo = (JsonPlatformInfo) response.getEntity();
+    assertNotNull(jsonPlatformInfo);
+    assertNull(jsonPlatformInfo.getBuildNumber());
+    assertNull(jsonPlatformInfo.getDateOfKeyGeneration());
+    assertNull(jsonPlatformInfo.getDuration());
+    assertNull(jsonPlatformInfo.getIsMobileCompliant());
+    assertNull(jsonPlatformInfo.getNbUsers());
+    assertNull(jsonPlatformInfo.getPlatformBuildNumber());
+    assertNull(jsonPlatformInfo.getPlatformEdition());
+    assertNull(jsonPlatformInfo.getPlatformRevision());
+    assertNull(jsonPlatformInfo.getProductCode());
+    assertNull(jsonPlatformInfo.getRunningProfile());
+    assertNull(jsonPlatformInfo.getUnlockKey());
+    assertEquals(PlatformInformationRESTService.MIN_MOBILE_SUPPORTED_VERSION, jsonPlatformInfo.getPlatformVersion());
+  }
+
+  public void testGetPlatformInformationAuthenticatedUser() throws Exception { // NOSONAR
+    startSessionAs("mary");
+    ContainerResponse response = service(HTTPMethods.GET.toString(), "/platform/info", StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    JsonPlatformInfo jsonPlatformInfo = (JsonPlatformInfo) response.getEntity();
+    assertNotNull(jsonPlatformInfo);
+    assertNull(jsonPlatformInfo.getBuildNumber());
+    assertNull(jsonPlatformInfo.getDateOfKeyGeneration());
+    assertNull(jsonPlatformInfo.getDuration());
+    assertNull(jsonPlatformInfo.getIsMobileCompliant());
+    assertNull(jsonPlatformInfo.getNbUsers());
+    assertNull(jsonPlatformInfo.getPlatformBuildNumber());
+    assertNull(jsonPlatformInfo.getPlatformEdition());
+    assertNull(jsonPlatformInfo.getPlatformRevision());
+    assertNull(jsonPlatformInfo.getProductCode());
+    assertNull(jsonPlatformInfo.getRunningProfile());
+    assertNull(jsonPlatformInfo.getUnlockKey());
+    assertEquals(PlatformInformationRESTService.MIN_MOBILE_SUPPORTED_VERSION, jsonPlatformInfo.getPlatformVersion());
+  }
+
+  public void testGetPlatformInformationAuthenticatedAdminUser() throws Exception { // NOSONAR
+    startSessionAs("root");
+    ContainerResponse response = service(HTTPMethods.GET.toString(), "/platform/info", StringUtils.EMPTY, null, null);
+    assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+    JsonPlatformInfo jsonPlatformInfo = (JsonPlatformInfo) response.getEntity();
+    assertNotNull(jsonPlatformInfo);
+    assertNotNull(jsonPlatformInfo.getPlatformBuildNumber());
+    assertNotNull(jsonPlatformInfo.getPlatformEdition());
+    assertNotNull(jsonPlatformInfo.getPlatformRevision());
+    assertNotNull(jsonPlatformInfo.getPlatformVersion());
+    assertNotEquals(PlatformInformationRESTService.MIN_MOBILE_SUPPORTED_VERSION, jsonPlatformInfo.getPlatformVersion());
+  }
+
+  private void startSessionAs(String user) {
+    try {
+      Authenticator authenticator = getContainer().getComponentInstanceOfType(Authenticator.class);
+      Identity userIdentity = authenticator.createIdentity(user);
+      ConversationState.setCurrent(new ConversationState(userIdentity));
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  private void endSession() {
+    ConversationState.setCurrent(null);
+  }
+
+  private void registry(Object resource) {
+    resourceBinder.addResource(resource, null);
+  }
+
+}

--- a/commons-component-product/src/test/resources/conf/configuration.xml
+++ b/commons-component-product/src/test/resources/conf/configuration.xml
@@ -36,6 +36,17 @@
     </init-params>
   </component>
 
+  <component>
+    <type>org.exoplatform.services.naming.InitialContextInitializer</type>
+    <init-params>
+      <properties-param>
+        <name>default-properties</name>
+        <description>Default initial context properties</description>
+        <property name="java.naming.factory.initial" value="org.exoplatform.services.naming.SimpleContextFactory" />
+      </properties-param>
+    </init-params>
+  </component>
+  
   <!-- Bind datasource -->
   <external-component-plugins>
     <target-component>org.exoplatform.services.naming.InitialContextInitializer</target-component>
@@ -60,7 +71,7 @@
           <name>ref-addresses</name>
           <description>ref-addresses</description>
           <property name="driverClassName" value="org.hsqldb.jdbcDriver" />
-          <property name="url" value="jdbc:hsqldb:mem:db1" />
+          <property name="url" value="jdbc:hsqldb:mem:db100" />
           <property name="username" value="sa" />
           <property name="password" value="" />
         </properties-param>
@@ -68,4 +79,5 @@
     </component-plugin>
   </external-component-plugins>
 
+  <remove-configuration>org.exoplatform.commons.persistence.impl.LiquibaseDataInitializer</remove-configuration>
 </configuration>

--- a/commons-component-product/src/test/resources/conf/portal/test-configuration.xml
+++ b/commons-component-product/src/test/resources/conf/portal/test-configuration.xml
@@ -21,11 +21,30 @@
   </component>
 
   <component>
+    <type>org.exoplatform.commons.info.PlatformInformationRESTService</type>
+  </component>
+
+  <component>
     <type>org.exoplatform.commons.info.ProductInformations</type>
     <init-params>
       <value-param>
         <name>product.versions.declaration.file</name>
         <value>classpath:/conf/data/product_new.properties</value>
+      </value-param>
+    </init-params>
+  </component>
+
+  <component>
+    <key>org.exoplatform.commons.api.persistence.DataInitializer</key>
+    <type>org.exoplatform.commons.persistence.impl.LiquibaseDataInitializer</type>
+    <init-params>
+      <value-param>
+        <name>liquibase.datasource</name>
+        <value>${exo.jpa.datasource.name:java:/comp/env/exo-jpa_portal}</value>
+      </value-param>
+      <value-param>
+        <name>liquibase.contexts</name>
+        <value>${exo.liquibase.contexts:production}</value>
       </value-param>
     </init-params>
   </component>


### PR DESCRIPTION
In commit https://github.com/Meeds-io/commons/commit/e6c3966ac4c36fb1f2d5145216bcffe8476d3233, the /platform/info endpoint has been protected to be accessible by administrators only to protect real platform version information. This information was needed by Mobile and thus, we will need to expose a minimum here the information that the version of eXo platform is compliant with Mobile application