### PR TITLE
Fix-40168: cKeditor removes empty i tags (#90) (#101)

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoConfig.js
+++ b/commons-extension-webapp/src/main/webapp/eXoConfig.js
@@ -33,6 +33,7 @@ CKEDITOR.editorConfig = function( config ){
 	config.pasteFromWordRemoveStyles = false;
         config.syntaxhighlight_lang = 'java';
 	config.syntaxhighlight_hideControls = true;
+	CKEDITOR.dtd.$removeEmpty['i'] = false;
 
   // style inside the editor
 	config.contentsCss = '/commons-extension/ckeditorCustom/contents.css';


### PR DESCRIPTION
Co-authored-by: wafakd <42204155+wafakd@users.noreply.github.com>
(cherry picked from commit 50f805bb4bbd0d79a38baa0f1601feda50b82b53)