### PR TITLE
Task-40050 Fix upper layer modules build

### DIFF
--- a/commons-dlp/src/main/java/org/exoplatform/commons/dlp/rest/DlpItemRestServices.java
+++ b/commons-dlp/src/main/java/org/exoplatform/commons/dlp/rest/DlpItemRestServices.java
@@ -33,16 +33,12 @@ public class DlpItemRestServices implements ResourceContainer {
     
     private DlpOperationProcessor dlpOperationProcessor;
     
-    private UserACL userACL;
-    
     public static final String TYPE = "file";
 
     public DlpItemRestServices(DlpPositiveItemService dlpPositiveItemService, 
-                               DlpOperationProcessor dlpOperationProcessor, 
-                               UserACL userACL) {
+                               DlpOperationProcessor dlpOperationProcessor) {
         this.dlpPositiveItemService = dlpPositiveItemService;
         this.dlpOperationProcessor = dlpOperationProcessor;
-        this.userACL = userACL;
     }
 
 
@@ -186,6 +182,7 @@ public class DlpItemRestServices implements ResourceContainer {
     )
     public Response checkIsMemberOfAdministratorGroup() {
       try {
+        UserACL userACL = CommonsUtils.getService(UserACL.class);
         boolean isAdmin = userACL.isSuperUser() || userACL.isUserInGroup(userACL.getAdminGroups());
         return Response.ok().entity("{\"isAdmin\":\"" + isAdmin + "\"}").build();
       } catch (Exception e) {


### PR DESCRIPTION
By adding DlpItemRestServices in conf/portal/configuration.xml of JAR, it will be instantiated in all upper layer Unit Tests. Thus, here we will avoid adding direct dependency to UserACL to be injected by constructor to avoid Unit Tests failure in upper layers.