### PR TITLE
TASK-40765 Update I18N URL when eXo version changed to force update browser cache

### DIFF
--- a/commons-extension-webapp/src/main/webapp/javascript/exo-i18n.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/exo-i18n.js
@@ -29,6 +29,11 @@
   }
 
   function fetchLangFile(url, lang) {
+    if (url && url.indexOf('?') >= 0) {
+      url = `${url}&v=${eXo.env.client.assetsVersion}`
+    } else {
+      url = `${url}?v=${eXo.env.client.assetsVersion}`
+    }
     return fetch(url, { credentials: 'include' })
       .then(function (resp) {
         return resp.json();


### PR DESCRIPTION
The Browser caches the JSON of Resource bundles for 1/2 day (https://github.com/Meeds-io/commons/blob/develop/commons-component-common/src/main/java/org/exoplatform/commons/resource/ResourceBundleREST.java#L45). Half a day was sufficient when doing the migration and upgrade from a version to another of the platform. Since few weekes, we had adopted CI/CD for Tribe and for weekly releases for some other deployments, thus this file has to be updated instantly from server when an upgrade was made. Thus, to ensure that, the URL to retrieve I18N resources is made **dynamic** by using assets version defined by the platform (that will vary switch deployed version), the assets version is added in the URL to force browser to refresh I18N resources, since the previous cached resource URL was different.