### PR TITLE
26741 : reset number on all pages when notification drawer is opened …

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/MessageInfo.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/MessageInfo.java
@@ -220,8 +220,9 @@ public class MessageInfo {
    * Sets the badge number of the user
    * @param numberOnBadge
    */
-  public void setNumberOnBadge(int numberOnBadge) {
+  public MessageInfo setNumberOnBadge(int numberOnBadge) {
     this.numberOnBadge = numberOnBadge;
+    return this;
   }
 
   @Override

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/WebNotificationServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/WebNotificationServiceImpl.java
@@ -31,6 +31,7 @@ import org.exoplatform.commons.api.notification.service.WebNotificationService;
 import org.exoplatform.commons.api.notification.service.storage.WebNotificationStorage;
 import org.exoplatform.commons.notification.channel.WebChannel;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
+import org.exoplatform.commons.notification.net.WebNotificationSender;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
@@ -106,6 +107,7 @@ public class WebNotificationServiceImpl implements WebNotificationService {
   @Override
   public void resetNumberOnBadge(String userId) {
     storage.resetNumberOnBadge(userId);
+    WebNotificationSender.sendJsonMessage(userId, new MessageInfo().setNumberOnBadge(0));
   }
 
   @Override


### PR DESCRIPTION
…in another tab (#109)

When we receive notifications, the badge shows the number of notifications unseen. when a tab is opened, the badge is reinitialized but other tabs are not.
This fix sends an empty Web notification with 0 as number of notifications to all opened tabs, to reset the notification badge.

(cherry picked from commit 436e013a2fe01079fca6fb1f6a4a5a641ac6cb13)