### PR TITLE
TASK-40887 Init CKEditor suggester plugin on data modification

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/suggester/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/suggester/plugin.js
@@ -53,6 +53,9 @@ require(['SHARED/jquery', 'SHARED/suggester'],function($) {
       editor.on('mode', function(e) {
         initSuggester(this, config);
       });
+      editor.on('dataReady', function(e) {
+        initSuggester(this, config);
+      });
       editor.on('instanceReady', function() {
         //initSuggester(editor, config);
       });


### PR DESCRIPTION
When using .setData of an exinsting CKEditor instance, the CKEDitor body gets replaced by a new one, thus the eXo suggester plugin doesn't find a placed data in previous body.
The proposed solution here is to initialize suggester again each time the method .setData of CKEditor gets called