### PR TITLE
TASK-41090 Fix editor suggester configuration initialization

### DIFF
--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/suggester.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/suggester.js
@@ -282,8 +282,16 @@
 
   $.fn.suggester = function(settings) {
     var _args = arguments;
-    var app, $this;
-    if (!(app = ($this = $(this)).data("suggester"))) {
+    var $this = $(this);
+    var app = $this.data("suggester");
+    const resetExistingEditor = app && (typeof settings === 'object');
+    if (resetExistingEditor) {
+      // The editor is already initialized,
+      // thus we ignore new initialization
+      return;
+    }
+
+    if (!app) {
       $this.data('suggester', (app = new App(this)));
     }
     var $input = $this, $editable;


### PR DESCRIPTION
When changing or calling several time the suggester initialization, the previous suggester gets dropped and replaced.
Thus the editor will not be ready to display the suggester when changing its data because it will be re-initializing on each added character.
This PR will avoid re-initializing twice (idempotent operation).