### PR TITLE
TASK-41090 stabilize suggester for CKEditor instance

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/suggester/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/suggester/plugin.js
@@ -46,7 +46,9 @@ require(['SHARED/jquery', 'SHARED/suggester'],function($) {
     init : function( editor ) {
       var config = editor.config.suggester;
       if (config == undefined) config = {};
-      config = $.extend(true, {}, defaultOptions, config);
+      config = $.extend(true, {
+        avoidReset: true,
+      }, defaultOptions, config);
       
       editor.addContentsCss( $('#ckeditor-suggester').attr('href') );
 
@@ -54,10 +56,12 @@ require(['SHARED/jquery', 'SHARED/suggester'],function($) {
         initSuggester(this, config);
       });
       editor.on('dataReady', function(e) {
-        initSuggester(this, config);
+        if (editor.instanceReady) {
+          initSuggester(this, config);
+        }
       });
       editor.on('instanceReady', function() {
-        //initSuggester(editor, config);
+        initSuggester(editor, config);
       });
       editor.on('getData', function(evt) {
         var data = evt.data;

--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/suggester.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/suggester.js
@@ -285,7 +285,7 @@
     var $this = $(this);
     var app = $this.data("suggester");
     const resetExistingEditor = app && (typeof settings === 'object');
-    if (resetExistingEditor) {
+    if (resetExistingEditor && settings.avoidReset) {
       // The editor is already initialized,
       // thus we ignore new initialization
       return;


### PR DESCRIPTION
The behavior of suggester differs in CKEditor comparing to a contenteditable or input. Thus, we use specific configuration for CKEditor configuration to avoid regression on contenteditable or inputs