### PR TITLE
TASK-41090 Fix editor suggester configuration initialization

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/suggester/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/suggester/plugin.js
@@ -46,7 +46,9 @@ require(['SHARED/jquery', 'SHARED/suggester'],function($) {
     init : function( editor ) {
       var config = editor.config.suggester;
       if (config == undefined) config = {};
-      config = $.extend(true, {}, defaultOptions, config);
+      config = $.extend(true, {
+        avoidReset: true,
+      }, defaultOptions, config);
       
       editor.addContentsCss( $('#ckeditor-suggester').attr('href') );
 
@@ -54,10 +56,12 @@ require(['SHARED/jquery', 'SHARED/suggester'],function($) {
         initSuggester(this, config);
       });
       editor.on('dataReady', function(e) {
-        initSuggester(this, config);
+        if (editor.instanceReady) {
+          initSuggester(this, config);
+        }
       });
       editor.on('instanceReady', function() {
-        //initSuggester(editor, config);
+        initSuggester(editor, config);
       });
       editor.on('getData', function(evt) {
         var data = evt.data;

--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/suggester.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/suggester.js
@@ -282,8 +282,16 @@
 
   $.fn.suggester = function(settings) {
     var _args = arguments;
-    var app, $this;
-    if (!(app = ($this = $(this)).data("suggester"))) {
+    var $this = $(this);
+    var app = $this.data("suggester");
+    const resetExistingEditor = app && (typeof settings === 'object');
+    if (resetExistingEditor && settings.avoidReset) {
+      // The editor is already initialized,
+      // thus we ignore new initialization
+      return;
+    }
+
+    if (!app) {
       $this.data('suggester', (app = new App(this)));
     }
     var $input = $this, $editable;


### PR DESCRIPTION
When changing or calling several time the suggester initialization, the previous suggester gets dropped and replaced.
Thus the editor will not be ready to display the suggester when changing its data because it will be re-initializing on each added character.
This PR will avoid re-initializing twice (idempotent operation).