### PR TITLE
Task-41504: Documents are not detected if they contain a keyword composed of more than a word

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
@@ -232,7 +232,7 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
         return queryPart;
       }).collect(Collectors.toList());
       String escapedQueryWithOROperator = StringUtils.join(queryParts, " OR ");
-      esQuery.append("            \"must\" : {\n");
+      esQuery.append("            \"should\" : {\n");
       esQuery.append("                \"query_string\" : {\n");
       esQuery.append("                    \"fields\" : [" + getFields() + "],\n");
       esQuery.append("                    \"query\" : \"" + escapedQueryWithOROperator + "\"\n");


### PR DESCRIPTION
The problem is that when the document contains only composed keyword and the dlp keywords contain both types (composed and single words), the document is not detected.

To fix this problem, we need to update the ES query (**should** instead of **must**) and only process the item that it contains the **expert** keywords.