### PR TITLE
Task-41606 : Notifications settings dlp part for admins I18N not set

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/GroupProvider.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/GroupProvider.java
@@ -23,7 +23,7 @@ import java.util.List;
 
 public class GroupProvider {
   public static final List<String> defaultGroupIds = Arrays.asList("general", "connections", 
-                                                                     "spaces", "activity_stream", "documents", "other");
+                                                                     "spaces", "activity_stream", "documents", "quarantine", "other");
 
   private String             groupId;
 

--- a/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_en.properties
+++ b/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_en.properties
@@ -3,6 +3,7 @@ UINotification.label.group.Connections=Connections
 UINotification.label.group.Spaces=Spaces
 UINotification.label.group.ActivityStream=Activity Stream
 UINotification.label.group.Documents=Document Sharing
+UINotification.label.group.Quarantine=Quarantine
 UINotification.label.group.Other=Other
 
 #############################################################################

--- a/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_fr.properties
+++ b/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_fr.properties
@@ -3,6 +3,7 @@ UINotification.label.group.Connections=R\u00E9seau
 UINotification.label.group.Spaces=Espaces
 UINotification.label.group.ActivityStream=Flux d'activit\u00E9
 UINotification.label.group.Documents=Documents Partag\u00E9s
+UINotification.label.group.Quarantine=Quarantaine
 UINotification.label.group.Other=Autre
 
 #############################################################################

--- a/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/notification-configuration.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/notification-configuration.xml
@@ -368,7 +368,7 @@
               <string>quarantine</string>
             </field>
             <field name="resourceBundleKey">
-              <string>UINotification.label.group.quarantine</string>
+              <string>UINotification.label.group.Quarantine</string>
             </field>
             <field name="order">
               <string>6</string>


### PR DESCRIPTION
Before this fix, DLP notifications for administrators are not I18N.
This fix will assure that admins notifications for DLP are I18N.