### PR TITLE
41879 : Improve exception handling when retrieving resource bundles

### DIFF
--- a/commons-webui-component/src/main/java/org/exoplatform/webui/utils/TimeConvertUtils.java
+++ b/commons-webui-component/src/main/java/org/exoplatform/webui/utils/TimeConvertUtils.java
@@ -179,12 +179,17 @@ public class TimeConvertUtils {
       res = bundleService.getResourceBundle("locale.commons.Commons", locale);
     }
     // still null
+    String keyString = key.substring(key.lastIndexOf(".") + 1).toLowerCase();
     if (res == null) {
       LOG.warn("Can not resource bundle by key: " + key);
-      return key.substring(key.lastIndexOf(".") + 1).toLowerCase();
+      return keyString;
     }
-
-    return res.getString(key);
+    try {
+      return res.getString(key);
+    } catch (java.util.MissingResourceException missingResourceException) {
+      LOG.warn("Can't find resource for key {}, language {}", key, locale.toString());
+      return keyString;
+    }
   }
   
   private static String getMessage(String message, String[] args) {


### PR DESCRIPTION
For an unknown reason yet, we have many exceptions on tribe about retrieving bundles for TimeConvertUtils that are inside Commons_LANG.properties already.
This PR will avoid the long exception stacktraces and will provide the key and the language for the missing bundle.