### PR TITLE
When DLP queue is processed, we dont know how many elements are treaten.

### DIFF
--- a/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
+++ b/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
@@ -88,6 +88,7 @@ public class DlpOperationProcessorImpl extends DlpOperationProcessor implements 
       int processedOperations;
       do {
         processedOperations = processBulk();
+        LOGGER.info("Dlp Operation Processor proceed {} queue elements",processedOperations);
       } while (processedOperations >= batchNumber);
     } finally {
       if (this.interrupted) {


### PR DESCRIPTION
This commit add a log for logging that information