### PR TITLE
DLP log is not relevant when treating dlpqueue

### DIFF
--- a/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
+++ b/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
@@ -85,11 +85,13 @@ public class DlpOperationProcessorImpl extends DlpOperationProcessor implements 
     try {
       // Loop until the number of data retrieved from dlp queue is less than
       // BATCH_NUMBER (default = 1000)
+      int totalProcessed=0;
       int processedOperations;
       do {
         processedOperations = processBulk();
-        LOGGER.info("Dlp Operation Processor proceed {} queue elements",processedOperations);
+        totalProcessed+=processedOperations;
       } while (processedOperations >= batchNumber);
+      LOGGER.info("Dlp Operation Processor proceed {} queue elements by batches of {}",totalProcessed, BATCH_NUMBER_DEFAULT);
     } finally {
       if (this.interrupted) {
         LOGGER.debug("Dlp queue processing interruption done");


### PR DESCRIPTION
Before this fix, the DLP Operation Processor write a lot of logs each second
This fix modify the log from one line by batches on line by job run