### PR TITLE
Task-42912: Don't display 2FA pages for users no-admins

### DIFF
--- a/commons-mfa/src/main/java/org/exoplatform/mfa/api/MfaService.java
+++ b/commons-mfa/src/main/java/org/exoplatform/mfa/api/MfaService.java
@@ -37,14 +37,12 @@ public class MfaService {
     
   }
 
-  public boolean canAccess() {
+  public boolean canAccess(String requestUri) {
     UserACL userACL = CommonsUtils.getService(UserACL.class);
     if (System.getProperty("exo.mfa.protectedGroupNavigations") != null) {
       String[] protectedGroup = System.getProperty("exo.mfa.protectedGroupNavigations").split(",") ;
-      for (String group : protectedGroup) {
-        if (userACL.isUserInGroup(group)) return true;
-      }
-
+      String currentGroup = requestUri.split("g/:")[1].split("/")[0].replace(":", "/");
+      if ( Arrays.toString(protectedGroup).contains(currentGroup) && userACL.isUserInGroup("/" + currentGroup) ) return true;
     }
     return false;
   }

--- a/commons-mfa/src/main/java/org/exoplatform/mfa/api/MfaService.java
+++ b/commons-mfa/src/main/java/org/exoplatform/mfa/api/MfaService.java
@@ -5,9 +5,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.mfa.api.otp.OtpConnector;
+import org.exoplatform.portal.config.UserACL;
 
 public class MfaService {
 
@@ -33,5 +35,17 @@ public class MfaService {
                                .filter(s -> requestUri.contains(s))
                                .count() > 0;
     
+  }
+
+  public boolean canAccess() {
+    UserACL userACL = CommonsUtils.getService(UserACL.class);
+    if (System.getProperty("exo.mfa.protectedGroupNavigations") != null) {
+      String[] protectedGroup = System.getProperty("exo.mfa.protectedGroupNavigations").split(",") ;
+      for (String group : protectedGroup) {
+        if (userACL.isUserInGroup(group)) return true;
+      }
+
+    }
+    return false;
   }
 }

--- a/commons-mfa/src/main/java/org/exoplatform/mfa/filter/MfaFilter.java
+++ b/commons-mfa/src/main/java/org/exoplatform/mfa/filter/MfaFilter.java
@@ -31,7 +31,7 @@ public class MfaFilter implements Filter {
 
     String requestUri = httpServletRequest.getRequestURI();
     if (mfaService.isProtectedUri(requestUri)) {
-      if ((session.getAttribute("mfaValidated")==null || !(boolean)session.getAttribute("mfaValidated")) && mfaService.canAccess()) {
+      if ((session.getAttribute("mfaValidated")==null || !(boolean)session.getAttribute("mfaValidated")) && mfaService.canAccess(requestUri)) {
           LOG.info("Mfa Filter must redirect on page to fill token");
           httpServletResponse.sendRedirect("/portal/dw/mfa-access?initialUri=" + requestUri);
           return;

--- a/commons-mfa/src/main/java/org/exoplatform/mfa/filter/MfaFilter.java
+++ b/commons-mfa/src/main/java/org/exoplatform/mfa/filter/MfaFilter.java
@@ -28,18 +28,18 @@ public class MfaFilter implements Filter {
     HttpSession session = httpServletRequest.getSession();
     ExoContainer container = PortalContainer.getInstance();
     MfaService mfaService = container.getComponentInstanceOfType(MfaService.class);
-  
+
     String requestUri = httpServletRequest.getRequestURI();
     if (mfaService.isProtectedUri(requestUri)) {
-      if (session.getAttribute("mfaValidated")==null || !(boolean)session.getAttribute("mfaValidated")) {
-        LOG.info("Mfa Filter must redirect on page to fill token");
-        httpServletResponse.sendRedirect("/portal/dw/mfa-access?initialUri="+requestUri);
-        return;
+      if ((session.getAttribute("mfaValidated")==null || !(boolean)session.getAttribute("mfaValidated")) && mfaService.canAccess()) {
+          LOG.info("Mfa Filter must redirect on page to fill token");
+          httpServletResponse.sendRedirect("/portal/dw/mfa-access?initialUri=" + requestUri);
+          return;
+        }
       }
-    }
-  
+
     chain.doFilter(request, response);
-  
-  
+
+
   }
 }


### PR DESCRIPTION
- Before this fix MFA pages are displayed for all users when they select protected pages.
- This fix will ensure that only members of protected MFA groups are allowed to display 2FA pages.