### PR TITLE
Task 42330 : [DLP] Some items are stuck in the queue

### DIFF
--- a/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
+++ b/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
@@ -93,6 +93,9 @@ public class DlpOperationProcessorImpl extends DlpOperationProcessor implements 
         LOGGER.debug("Process Bulk DLP operation (offset : {}, total {})", offset, total);
         int stayingQueue = processBulk(offset);
         int processedOperations = batchNumber - stayingQueue;
+        if (total<batchNumber) {
+          processedOperations= (int) (total-stayingQueue);
+        }
         total = dlpOperationDAO.count();
         offset += stayingQueue;
         totalProcessed = totalProcessed + processedOperations;


### PR DESCRIPTION
Before this fix, the counter which count total processed is not ok for the last loop. It displays the batchSize instead the real last page size.
This commit change that to display the correct last page size