### PR TITLE
TASK-26265 centralise third party libraries versions in maven-depmgt-pom

### DIFF
--- a/commons-api/pom.xml
+++ b/commons-api/pom.xml
@@ -21,7 +21,6 @@
     <dependency>
       <groupId>javax.websocket</groupId>
       <artifactId>javax.websocket-api</artifactId>
-      <version>1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/commons-comet-service/pom.xml
+++ b/commons-comet-service/pom.xml
@@ -108,7 +108,6 @@
     <dependency>
       <groupId>javax.websocket</groupId>
       <artifactId>javax.websocket-api</artifactId>
-      <version>1.0</version>
       <scope>provided</scope>
     </dependency>
     <!-- New Cometd -->

--- a/commons-comet-service/src/main/java/org/exoplatform/ws/frameworks/cometd/ServletContextWrapper.java
+++ b/commons-comet-service/src/main/java/org/exoplatform/ws/frameworks/cometd/ServletContextWrapper.java
@@ -326,5 +326,10 @@ public class ServletContextWrapper implements ServletContext {
   @Override
   public void setSessionTrackingModes(Set<SessionTrackingMode> arg0) {
     delegate.setSessionTrackingModes(arg0);    
+  }
+
+  @Override
+  public String getVirtualServerName() {
+    return delegate.getVirtualServerName();
   } 
 }

--- a/commons-gifbackport/pom.xml
+++ b/commons-gifbackport/pom.xml
@@ -7,7 +7,7 @@
     <version>6.2.x-SNAPSHOT</version>
   </parent>
   <artifactId>commons-gifbackport</artifactId>
-  <version>6.2.x-SNAPSHOT</version>
+
   <packaging>jar</packaging>
   <name>eXo PLF:: Commons - Component GIF plugin backport</name>
   <description>eXo javax.imageio GIF plugin backport</description>

--- a/commons-search/pom.xml
+++ b/commons-search/pom.xml
@@ -97,24 +97,6 @@
       <artifactId>ingest-attachment</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${org.apache.log4j.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>${org.apache.log4j.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>${commons-logging.version}</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/commons-testing/src/main/java/org/exoplatform/commons/testing/mock/MockServletContext.java
+++ b/commons-testing/src/main/java/org/exoplatform/commons/testing/mock/MockServletContext.java
@@ -272,4 +272,9 @@ public class MockServletContext implements ServletContext {
     return null;
   }
 
+  @Override
+  public String getVirtualServerName() {
+    return null;
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -27,45 +27,21 @@
     <module>commons-webui-component</module>
     <module>commons-webui-ext</module>
     <module>commons-search</module>
-	<module>commons-dlp</module>
+    <module>commons-dlp</module>
   </modules>
   <scm>
-    <connection>scm:git:git://github.com/exoplatform/commons.git</connection>
-    <developerConnection>scm:git:git@github.com:exoplatform/commons.git</developerConnection>
+    <connection>scm:git:git://github.com/meeds-io/commons.git</connection>
+    <developerConnection>scm:git:git@github.com:meeds-io/commons.git</developerConnection>
+    <url>https://github.com/meeds-io/commons</url>
     <tag>HEAD</tag>
-    <url>http://fisheye.exoplatform.org/browse/projects/commons</url>
   </scm>
   <properties>
     <!-- **************************************** -->
-    <!-- Jira Settings                            -->
+    <!-- Project Dependencies                     -->
     <!-- **************************************** -->
-    <jira.project.key>COMMONS</jira.project.key>
-    <!-- **************************************** -->
-    <!-- Jenkins Settings                         -->
-    <!-- **************************************** -->
-    <jenkins.job.name>commons-master-ci</jenkins.job.name>
-    <!-- **************************************** -->
-    <!-- Build Settings                           -->
-    <!-- **************************************** -->
-    <skipTests>false</skipTests>
-    <skipUTests>${skipTests}</skipUTests>
-    <skipITests>${skipTests}</skipITests>
-    <!-- **************************************** -->
-    <!-- Dependencies versions                    -->
-    <!-- **************************************** -->
-    <!-- GateIn Project Dependencies -->
     <org.exoplatform.gatein.portal.version>6.2.x-SNAPSHOT</org.exoplatform.gatein.portal.version>
-    <!-- Platform Project Dependencies -->
-    <org.apache.log4j.version>2.7</org.apache.log4j.version>
-    <commons-logging.version>1.1.3</commons-logging.version>
-    <org.joda.time.version>2.8.2</org.joda.time.version>
   </properties>
   <dependencyManagement>
-    <!-- ### NEVER CHANGE THIS ORDER OF DEPMGT ### -->
-    <!-- * From top level to bottom projects -->
-    <!-- * maven-depmgt-pom must be the first -->
-    <!-- * Your own modules -->
-    <!-- * And projects below you -->
     <dependencies>
       <!-- Import versions from platform-ui project -->
       <dependency>
@@ -243,49 +219,7 @@
             <packagingExcludes>WEB-INF/lib/*.jar</packagingExcludes>
           </configuration>
         </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <skipTests>${skipUTests}</skipTests>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-failsafe-plugin</artifactId>
-          <configuration>
-            <skipTests>${skipITests}</skipTests>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
   </build>
-  <profiles>
-    <profile>
-      <id>project-repositories</id>
-      <activation>
-        <property>
-          <name>!skip-project-repositories</name>
-        </property>
-      </activation>
-      <repositories>
-        <repository>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-          <id>repository.exoplatform.org</id>
-          <url>https://repository.exoplatform.org/public</url>
-        </repository>
-      </repositories>
-      <pluginRepositories>
-        <pluginRepository>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
-          <id>repository.exoplatform.org</id>
-          <url>https://repository.exoplatform.org/public</url>
-        </pluginRepository>
-      </pluginRepositories>
-    </profile>
-  </profiles>
 </project>


### PR DESCRIPTION
This PR will :
* centralise maven plugin dependencies by changing parent POM to use `maven-parent-pom:org.exoplatform` in order to ease the maintenance and coherence of developed artifacts
* centralise jar dependencies in order to ensure jar versions coherence between all projects and avoid bad jar versions in runtime. This will ease the maintenance and update of jar dependencies as well.
* Implement missing Servlet API methods