### PR TITLE
TASK-26265 Fix antlr version for plugin lesscss-maven-plugin

### DIFF
--- a/commons-extension-webapp/pom.xml
+++ b/commons-extension-webapp/pom.xml
@@ -13,15 +13,6 @@
     <!-- Use version required by Juzu Less plugin -->
     <org.antlr.runtime.version>3.4</org.antlr.runtime.version>
   </properties>
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr-runtime</artifactId>
-        <version>${org.antlr.runtime.version}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <!-- Current project dependencies -->
@@ -139,6 +130,13 @@
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>${org.antlr.runtime.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
The plugin lesscss-maven-plugin has been deprecated and has old dependencies such as antlr library that has a breaking change. The other artifacts used antlr 3.5 while this plugin is compatible with antlr 3.4 only.
To fix this, the dependency to antlr 3.4 has been added to the plugin declaration only.