### PR TITLE
Ensure upgrade plugins execution with continuous delivery versions

### DIFF
--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/version/util/ComparableVersion.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/version/util/ComparableVersion.java
@@ -299,8 +299,7 @@ public class ComparableVersion
                 {
                     return 0; // 1-0 = 1- (normalize) = 1
                 }
-                Item first = get( 0 );
-                return first.compareTo( null );
+                return -1;
             }
             switch ( item.getType() )
             {

--- a/commons-component-upgrade/src/test/java/org/exoplatform/commons/version/util/VersionComparatorTest.java
+++ b/commons-component-upgrade/src/test/java/org/exoplatform/commons/version/util/VersionComparatorTest.java
@@ -11,6 +11,15 @@ public class VersionComparatorTest extends TestCase {
     assertFalse(VersionComparator.isBefore("2.1", ""));
     assertTrue(VersionComparator.isBefore("", "2.2"));
     assertTrue(VersionComparator.isBefore("5.0.0-M32", "5.0-RC1"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210529", "6.2.0-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.0-20210601", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.2.1-20210529", "6.2.1-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.1-20210601", "6.2.1-20210531"));
+    assertTrue(VersionComparator.isBefore("6.1.0", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.1.1", "6.2.0-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.0", "6.2.0-M20"));
+    assertFalse(VersionComparator.isBefore("6.2.0", "6.2.0-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.1", "6.2.0-20210531"));
   }
 
   public void testIsAfter() {

--- a/commons-component-upgrade/src/test/java/org/exoplatform/commons/version/util/VersionComparatorTest.java
+++ b/commons-component-upgrade/src/test/java/org/exoplatform/commons/version/util/VersionComparatorTest.java
@@ -19,7 +19,9 @@ public class VersionComparatorTest extends TestCase {
     assertTrue(VersionComparator.isBefore("6.1.1", "6.2.0-20210531"));
     assertFalse(VersionComparator.isBefore("6.2.0", "6.2.0-M20"));
     assertFalse(VersionComparator.isBefore("6.2.0", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210531", "6.2.0"));
     assertFalse(VersionComparator.isBefore("6.2.1", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210531", "6.2.1"));
   }
 
   public void testIsAfter() {


### PR DESCRIPTION
Prior to this change, upgrade plugins are ignored by continuous delivery versions since the target version is before the previous version. Thus we fix the version comparison in that case in order to ensure the upgrade plugin execution.