### PR TITLE
Task-38258 Dlp job is launched even if no keyword provided

### DIFF
--- a/commons-dlp/src/main/java/org/exoplatform/commons/dlp/job/DlpJob.java
+++ b/commons-dlp/src/main/java/org/exoplatform/commons/dlp/job/DlpJob.java
@@ -22,7 +22,8 @@ public class DlpJob implements InterruptableJob {
   @Override
   public void execute(JobExecutionContext context) throws JobExecutionException {
     ExoFeatureService featureService = CommonsUtils.getService(ExoFeatureService.class);
-    if (featureService.isActiveFeature(DlpOperationProcessor.DLP_FEATURE)) {
+    DlpOperationProcessor dlpService = CommonsUtils.getService(DlpOperationProcessor.class);
+    if (featureService.isActiveFeature(DlpOperationProcessor.DLP_FEATURE) && dlpService.hasKeywords()) {
       LOGGER.debug("Running dlp job");
       getDlpOperationProcessor().process();
     }

--- a/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/DlpOperationProcessor.java
+++ b/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/DlpOperationProcessor.java
@@ -53,6 +53,11 @@ public abstract class DlpOperationProcessor {
    * @return the Dlp Keywords
    */
   public abstract String getKeywords();
+  
+  /**
+   * @return the Dlp Keywords
+   */
+  public abstract boolean hasKeywords();
 
   /**
    * Set the Dlp Keywords

--- a/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
+++ b/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import org.apache.commons.lang.StringUtils;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.SettingValue;
 import org.exoplatform.commons.api.settings.data.Context;
@@ -69,7 +70,12 @@ public class DlpOperationProcessorImpl extends DlpOperationProcessor implements 
     SettingValue<?> settingValue = settingService.get(DLP_CONTEXT, DLP_SCOPE, EXO_DLP_KEYWORDS);
     return settingValue != null ? settingValue.getValue().toString() : System.getProperty(DLP_KEYWORDS);
   }
-
+  
+  @Override
+  public boolean hasKeywords() {
+    return !StringUtils.isEmpty(getKeywords());
+  }
+  
   @Override
   public void setKeywords(String keywords) {
     SettingService settingService = CommonsUtils.getService(SettingService.class);

--- a/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
+++ b/commons-dlp/src/main/java/org/exoplatform/commons/dlp/processor/impl/DlpOperationProcessorImpl.java
@@ -108,7 +108,11 @@ public class DlpOperationProcessorImpl extends DlpOperationProcessor implements 
         LOGGER.debug("DLP Operation processed : {} elements removed from queue, {} staying in queue, {} total elements in queue"
             + " after operation", processedOperations, stayingQueue, total);
       }
-      LOGGER.info("Dlp Operation Processor proceed {} queue elements, {} elements staying in queue", totalProcessed, offset);
+      if (totalProcessed==0 && offset==0) {
+        LOGGER.debug("Dlp Operation Processor proceed {} queue elements, {} elements staying in queue", totalProcessed, offset);
+      } else {
+        LOGGER.info("Dlp Operation Processor proceed {} queue elements, {} elements staying in queue", totalProcessed, offset);
+      }
     } catch (Exception e) {
       LOGGER.error("Error when processing bulk", e);
     } finally {


### PR DESCRIPTION
Before this fix, on a fresh install, the dlp job is launch even if no keyword provided
This fix add a test to not run the job if no keywords