### PR TITLE
Security Dependencies Update

### DIFF
--- a/commons-component-product/pom.xml
+++ b/commons-component-product/pom.xml
@@ -74,10 +74,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15</artifactId>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/commons-mfa/pom.xml
+++ b/commons-mfa/pom.xml
@@ -38,11 +38,6 @@
     </dependency>
     <dependency>
       <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
       <artifactId>powermock-api-mockito2</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Update security versions : 
- ch.qos.logback:logback-classic from 1.1.2 to 1.2.3
- dom4j:dom4j:1.6.1 to org.dom4j:dom4j:2.1.3

Remove dependencies on
- org.bouncycastle:bcprov-jdk15:1.45
- org.bouncycastle:bcmail-jdk15:1.45
- org.bouncycastle:bctsp-jdk15:1.45
In eXo, we do not need theses dependencies.
bcprov and bcmail are bring by tika-parsers dependency in version 1.67
bctsp is no more needed