### PR TITLE
Fix Version comparaison for Upgrade plugin for CI/CD

### DIFF
--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/version/util/ComparableVersion.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/version/util/ComparableVersion.java
@@ -28,6 +28,8 @@ import java.util.ListIterator;
 import java.util.Locale;
 import java.util.Properties;
 import java.util.Stack;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -65,6 +67,8 @@ import org.exoplatform.services.log.Log;
 public class ComparableVersion
     implements Comparable<ComparableVersion>
 {
+    private static final Pattern CICD_VERSION_PATTERN = Pattern.compile("(.*)-([0-9]{8})$");
+
     private String value;
 
     private String canonical;
@@ -155,7 +159,7 @@ public class ComparableVersion
     {
         private static final Log LOG = ExoLogger.getLogger(StringItem.class);
         
-        private static final String[] QUALIFIERS = { "snapshot", "alpha", "beta", "milestone", "rc", "", "sp" };
+        private static final String[] QUALIFIERS = { "snapshot", "alpha", "beta", "cicd", "milestone", "rc", "", "sp" };
 
         private static final List<String> _QUALIFIERS = Arrays.asList( QUALIFIERS );
 
@@ -359,7 +363,12 @@ public class ComparableVersion
 
     public final void parseVersion( String version )
     {
-        this.value = version;
+        Matcher matcher = CICD_VERSION_PATTERN.matcher(version.trim());
+        if (matcher.find()) {
+          this.value = version = matcher.replaceFirst("$1-cicd$2");
+        } else {
+          this.value = version;
+        }
 
         items = new ListItem();
 

--- a/commons-component-upgrade/src/test/java/org/exoplatform/commons/version/util/VersionComparatorTest.java
+++ b/commons-component-upgrade/src/test/java/org/exoplatform/commons/version/util/VersionComparatorTest.java
@@ -11,6 +11,24 @@ public class VersionComparatorTest extends TestCase {
     assertFalse(VersionComparator.isBefore("2.1", ""));
     assertTrue(VersionComparator.isBefore("", "2.2"));
     assertTrue(VersionComparator.isBefore("5.0.0-M32", "5.0-RC1"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210529", "6.2.0-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.0-20210601", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.1.1", "6.2.0-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.0", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210529", "6.2.0-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.0-20210601", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.2.1-20210529", "6.2.1-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.1-20210601", "6.2.1-20210531"));
+    assertTrue(VersionComparator.isBefore("6.1.0", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.1.1", "6.2.0-20210531"));
+    assertFalse(VersionComparator.isBefore("6.2.0", "6.2.0-M20"));
+    assertFalse(VersionComparator.isBefore("6.2.0", "6.2.0-20210531"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210531", "6.2.0"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210531", "6.2.1"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210531", "6.2.0-m01"));
+    assertTrue(VersionComparator.isBefore("6.2.0-20210531", "6.2.0-rc01"));
+    assertTrue(VersionComparator.isBefore("6.2.0-rc02", "6.2.0-rc03"));
+    assertTrue(VersionComparator.isBefore("6.2.0-m15", "6.2.0-rc03"));
   }
 
   public void testIsAfter() {


### PR DESCRIPTION
Prior to this change, the CI/CD versions comparaison doesn't work efficiently. This change will ensure that Milestone version will be always considered as an upgrade of CI/CD versions and that CI/CD version are before GA version