### PR TITLE
Task-40396 : Allow target attribute in HTML links

### DIFF
--- a/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -518,7 +518,14 @@
       <adapter>
         (function() {
           <include>/javascript/purify.min.js</include>
-          Vue.directive('sanitized-html',(el, binding) => el.innerHTML = DOMPurify.sanitize(Autolinker.link(binding.value, {newWindow: true}), {USE_PROFILES: {html: true}}));
+          Vue.directive('sanitized-html',(el, binding) =>
+          DOMPurify.addHook('afterSanitizeAttributes', function (node) {
+          // add noopener attribute to external links to eliminate vulnerabilities
+          if ('target' in node) {
+          node.setAttribute('rel', 'noopener');
+          }
+          });
+          el.innerHTML = DOMPurify.sanitize(Autolinker.link(binding.value, {newWindow: true}), {USE_PROFILES: {html: true},ADD_ATTR: ['target']}));
         })();
       </adapter>
     </script>


### PR DESCRIPTION
Before this fix , internal and external links in chat are opened in the same tab , so i refactored the behavior of v-sanitized-html directive in order to keep the target attribute on the external links so that they can be opened in a new tab.
