### PR TITLE
TASK-46753 Remove Old Stream and replace Juzu dependencies in commons-extension

### DIFF
--- a/commons-extension-webapp/pom.xml
+++ b/commons-extension-webapp/pom.xml
@@ -82,12 +82,14 @@
     <dependency>
       <groupId>org.juzu</groupId>
       <artifactId>juzu-plugins-portlet</artifactId>
-      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.juzu</groupId>
+      <artifactId>juzu-plugins-upload</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>commons-juzu</artifactId>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.exoplatform.gatein.portal</groupId>


### PR DESCRIPTION
Prior to this changes, the commons-juzu and juzu-plugin-portlet + juzu-plugin-upload was added in package through a social artifact. This change will ensure to add the transitive dependency using commons, as long as commons-juzu is required