### PR TITLE
Fix build : move mfa configuration to extension

### DIFF
--- a/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/mfa-configuration.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/mfa-configuration.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<configuration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
-               xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
 
     <component>
@@ -36,7 +37,7 @@
             </value-param>
         </init-params>
     </component>
-    
+
     <component>
         <key>org.exoplatform.mfa.rest.mfa.MfaRestService</key>
         <type>org.exoplatform.mfa.rest.mfa.MfaRestService</type>
@@ -67,7 +68,7 @@
                     <name>Mfa Redirect Filter</name>
                     <object type="org.exoplatform.web.filter.FilterDefinition">
                         <field name="filter">
-                            <object type="org.exoplatform.mfa.filter.MfaFilter" />
+                            <object type="org.exoplatform.mfa.filter.MfaFilter"/>
                         </field>
                         <field name="patterns">
                             <collection type="java.util.ArrayList" item-type="java.lang.String">
@@ -112,7 +113,7 @@
             </init-params>
         </component-plugin>
     </external-component-plugins>
-    
+
     <external-component-plugins>
         <target-component>org.exoplatform.mfa.api.otp.OtpService</target-component>
         <component-plugin>
@@ -148,7 +149,6 @@
             </init-params>
         </component-plugin>
     </external-component-plugins>
-
 
 
 </configuration>

--- a/commons-mfa/src/test/java/org/exoplatform/mfa/api/MfaServiceTest.java
+++ b/commons-mfa/src/test/java/org/exoplatform/mfa/api/MfaServiceTest.java
@@ -4,6 +4,9 @@ import org.exoplatform.commons.api.settings.ExoFeatureService;
 import org.exoplatform.commons.api.settings.SettingService;
 import org.exoplatform.commons.api.settings.data.Context;
 import org.exoplatform.commons.api.settings.data.Scope;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
 import org.exoplatform.container.xml.ValueParam;
 import org.exoplatform.container.xml.InitParams;
 
@@ -30,7 +33,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.mock;
 
 public class MfaServiceTest {
   

--- a/commons-mfa/src/test/resources/conf/portal/configuration.xml
+++ b/commons-mfa/src/test/resources/conf/portal/configuration.xml
@@ -24,6 +24,18 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </component>
 
   <component>
+    <key>org.exoplatform.mfa.storage.MfaStorage</key>
+    <type>org.exoplatform.mfa.storage.MfaStorage</type>
+  </component>
+
+
+  <component>
+    <key>org.exoplatform.mfa.storage.dao.RevocationRequestDAO</key>
+    <type>org.exoplatform.mfa.storage.dao.RevocationRequestDAO</type>
+  </component>
+
+
+  <component>
     <key>org.exoplatform.portal.config.UserACL</key>
     <type>org.exoplatform.portal.config.UserACL</type>
     <init-params>


### PR DESCRIPTION
Before this commit, upper module like kudos try to instanciate Mfa Service, and create problem in build
We move mfa configuration in commons-extension, so that, kudos will not try to instanciate