### PR TITLE
TASK-46966 Avoid swallow and hide exception about missing Notification Templates

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/template/TemplateUtils.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/template/TemplateUtils.java
@@ -113,7 +113,7 @@ public class TemplateUtils {
       reader = new InputStreamReader(getTemplateInputStream(templatePath));
       IOTools.copy(reader, templateText);
     } catch (Exception e) {
-      LOG.debug("Failed to reader template file: " + templatePath, e);
+      LOG.warn("Failed to read template file: {}. An empty message will be used", templatePath, e);
     } finally {
       if (reader != null) {
         reader.close();


### PR DESCRIPTION
Prior to this change, When a template notification is missing, no exception message is displayed only for debug level.
This fix will ensure to make this important inconsistency visible when starting the server.