### PR TITLE
MAINT-28272: Fix snapshot myWork documents portlet listing order update

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchFilterType.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchFilterType.java
@@ -25,7 +25,8 @@ public enum  ElasticSearchFilterType {
   FILTER_BY_TERM("term"),
   FILTER_EXIST("exist"),
   FILTER_NOT_EXIST("notExist"),
-  FILTER_CUSTOM("custom");
+  FILTER_CUSTOM("custom"),
+  FILTER_MY_WORK_DOCS("myWork");
 
   private final String filterType;
 

--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
@@ -521,15 +521,18 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
     StringBuilder filterJSON = new StringBuilder();
 
     for (ElasticSearchFilter filter: filters) {
-
-      filterJSON.append("                  ,\n");
-      filterJSON.append("                  {\n");
-      filterJSON.append("                   \"bool\" : {\n");
-      filterJSON.append("                     \"should\" : [\n");
-      filterJSON.append("                      " + getFilter(filter) + "\n");
-      filterJSON.append("                       ]\n");
-      filterJSON.append("                    }\n");
-      filterJSON.append("                  }");
+      if (filter.getType().equals(ElasticSearchFilterType.FILTER_MY_WORK_DOCS)) {
+        filterJSON.append(getFilter(filter));
+      } else {
+        filterJSON.append("                  ,\n");
+        filterJSON.append("                  {\n");
+        filterJSON.append("                   \"bool\" : {\n");
+        filterJSON.append("                     \"should\" : [\n");
+        filterJSON.append("                      " + getFilter(filter) + "\n");
+        filterJSON.append("                       ]\n");
+        filterJSON.append("                    }\n");
+        filterJSON.append("                  }");
+      }
 
     }
 
@@ -547,6 +550,8 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
         return getNotExistFilter(filter.getField());
       case FILTER_CUSTOM:
         return getCustomFilter(filter.getValue());
+      case FILTER_MY_WORK_DOCS:
+        return myWorkDocumentsFilter(filter.getValue());
     }
     return "";
   }
@@ -606,7 +611,17 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
   private String getCustomFilter(String value) {
     return value;
   }
+  private String myWorkDocumentsFilter(String value) {
+    StringBuilder filterJSON = new StringBuilder();
+    filterJSON.append("                  ,\n");
+    filterJSON.append("                  {\n");
+    filterJSON.append("                   \"bool\" : {\n");
+    filterJSON.append("                       " + value + "\n");
+    filterJSON.append("                    }\n");
+    filterJSON.append("                  }");
 
+    return filterJSON.toString();
+  }
   protected String getPermissionFilter() {
     StringBuilder permissionSB = new StringBuilder();
     Set<String> membershipSet = getUserMemberships();


### PR DESCRIPTION
**ISSUE**: The elasticsearch query for retrieving documents wasn't musting the modifiedBy field to be only the user who modified the document,
So, when someone else updates the documents which im the owner, it goes on up the list of myWork docs as that i'm the modifier while it's not the case.
**FIX**: Correct the elasticSearch filter by using the bool query must clause instead of should in this particular case.