### PR TITLE
TASK-43255 : fixed notes unsearchable from unified search (#231)

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
@@ -598,7 +598,7 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
     return ConversationState.getCurrent().getIdentity().getUserId();
   }
 
-  private Set<String> getUserMemberships() {
+  protected Set<String> getUserMemberships() {
     ConversationState conversationState = ConversationState.getCurrent();
     if (conversationState == null) {
       throw new IllegalStateException("No Identity found: ConversationState.getCurrent() is null");


### PR DESCRIPTION
with unifiedSearch only we get the keyword and the type while searching wiki needs permission with is generated in a different way with the indexed permission
changed the retrieving permission while searching a wiki by extending getUserMemberships()