### PR TITLE
MAINT-41192: Fix ui issue when write a dot as first char for users mention suggester input

### DIFF
--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
@@ -107,7 +107,7 @@ DEFAULT_CALLBACKS = {
     if (!query) {
       return li;
     }
-    regexp = new RegExp(">\\s*([^\<]*?)(" + query.replace("+", "\\+") + ")([^\<]*)\\s*<", 'ig');
+    regexp = new RegExp(">\\s*([^\<]*?)(" + query.replace(/([.+])/g, "\\$1") + ")([^\<]*)\\s*<", 'ig');
     return li.replace(regexp, function(str, $1, $2, $3) {
       return '> ' + $1 + '<strong>' + $2 + '</strong>' + $3 + ' <';
     });


### PR DESCRIPTION
**ISSUE**: When there is a username that contains a dot char, the highlighter function in the suggester module as part of its
functionalities tries to highlite a suggestion result using regex that was creating during runtime but when there is only a dot as input
the regex wasn't escape the **dot** but instead it gives a wrong role **(.)** which means in regex logic is a special character used to match any one character, so it causes an unexpected ui issue.
**FIX**: Correct the regex by escaping the dot char when its exist in the suggester input