### PR TITLE
TASK-48563 Add Trace Log for BulkIndexingJob execution duration

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/job/BulkIndexingJob.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/job/BulkIndexingJob.java
@@ -37,8 +37,14 @@ public class BulkIndexingJob implements InterruptableJob {
   @Override
   public void execute(JobExecutionContext context) throws JobExecutionException {
     LOG.debug("Running job BulkIndexingJob");
-
+    long startTime = System.currentTimeMillis();
     getIndexingOperationProcessor().process();
+    long duration = System.currentTimeMillis() - startTime;
+    if (duration > 60000) {
+      LOG.info("End running BulkIndexingJob in {}ms", duration);
+    } else {
+      LOG.debug("End running BulkIndexingJob in {}ms", duration);
+    }
   }
 
   @Override


### PR DESCRIPTION
Prior to this change, the BulkIndexingJob execution time was unknown. This change will ensure to log the duration of this Job execution, in INFO level when it exceeds 1 minute, else in DEBUG level