### PR TITLE
Task-48467 : Fix the notification message when email input is invalid

### DIFF
--- a/commons-extension-webapp/src/main/java/org/exoplatform/platform/portlet/juzu/notificationsAdmin/templates/index.gtmpl
+++ b/commons-extension-webapp/src/main/java/org/exoplatform/platform/portlet/juzu/notificationsAdmin/templates/index.gtmpl
@@ -123,8 +123,8 @@
 		<span id="Error">${_ctx.appRes("NotificationAdmin.label.Error")}</span>
 		<span id="msgSaveOK">${_ctx.appRes("NotificationAdmin.msg.saveOK")}</span>
 		<span id="msgSaveKO">${_ctx.appRes("NotificationAdmin.msg.saveKO")}</span>
-		<span id="msgNameNok">${_ctx.appRes("NotificationAdmin.msg.NameNOK")}</span>
-		<span id="msgEmailNok">${_ctx.appRes("NotificationAdmin.msg.EmailNOK")}</span>
+		<span id="msgInvalidName">${_ctx.appRes("NotificationAdmin.msg.invalidName")}</span>
+		<span id="msgInvalidEmail">${_ctx.appRes("NotificationAdmin.msg.invalidEmail")}</span>
 	</div>
 
 </div>

--- a/commons-extension-webapp/src/main/resources/locale/portlet/notification/notificationsAdmin_en.properties
+++ b/commons-extension-webapp/src/main/resources/locale/portlet/notification/notificationsAdmin_en.properties
@@ -18,5 +18,5 @@ NotificationAdmin.label.Error=Error
 NotificationAdmin.label.NoNotifications=No notifications
 NotificationAdmin.msg.saveOK=Notifications will now be sent to your users from "{0}"<{1}>
 NotificationAdmin.msg.saveKO=Cannot update the sender information: empty value or the format is not correct.
-NotificationAdmin.msg.NameNok=The Name field must contain only characters
-NotificationAdmin.msg.EmailNok=You must add valid email Address(Multiple emails must be separated by comma)
+NotificationAdmin.msg.invalidName=The Name field must contain only characters
+NotificationAdmin.msg.invalidEmail=You must add valid email Address(Multiple emails must be separated by comma)

--- a/commons-extension-webapp/src/main/resources/locale/portlet/notification/notificationsAdmin_fr.properties
+++ b/commons-extension-webapp/src/main/resources/locale/portlet/notification/notificationsAdmin_fr.properties
@@ -18,5 +18,5 @@ NotificationAdmin.label.Error=Erreur
 NotificationAdmin.label.NoNotifications=Aucune notification
 NotificationAdmin.msg.saveOK=Les notifications seront d\u00E9sormais envoy\u00E9es \u00E0 vos utilisateurs par "{0}"<{1}>
 NotificationAdmin.msg.saveKO=Impossible de mettre \u00E0 jour les informations de l'exp\u00E9diteur: valeur vide ou le format n'est pas correct.
-NotificationAdmin.msg.NameNok=Le champ Nom ne doit contenir que des caract\u00E8res
-NotificationAdmin.msg.EmailNok=Vous devez ajouter une adresse email valide (les emails multiples doivent \u00EAtre s\u00E9par\u00E9s par des virgules)
+NotificationAdmin.msg.invalidName=Le champ Nom ne doit contenir que des caract\u00E8res
+NotificationAdmin.msg.invalidEmail=Vous devez ajouter une adresse email valide (les emails multiples doivent \u00EAtre s\u00E9par\u00E9s par des virgules)

--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/admin/notificationsAdmin.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/admin/notificationsAdmin.js
@@ -17,8 +17,8 @@
       msg : {
         OK : $("span#msgSaveOK", localizeStatus).text(),
         NOK: $("span#msgSaveKO", localizeStatus).text(),
-        NameNOK: $("span#msgNameNok", localizeStatus).text(),
-        EmailNOK: $("span#msgEmailNok", localizeStatus).text()
+        NameNOK: $("span#msgInvalidName", localizeStatus).text(),
+        EmailNOK: $("span#msgInvalidEmail", localizeStatus).text()
       },
       init : function() {
     	$("a.edit-setting").click(function() {


### PR DESCRIPTION
Issue: notification message when email or name input is invalid (EmailNOK, NameNOK).
Solution: Change the name EmailNOK and NameNOK to invalidEmail and InvalidName because they cause confusion on notificationAdmin.js file with IDs of labels and status.