### PR TITLE
Task-49104 Allow to extend Search Document API

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/domain/Document.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/domain/Document.java
@@ -161,7 +161,11 @@ public class Document {
   }
 
   public String toJSON() {
-    String json;
+    JSONObject json = toJsonObject();
+    return json.toJSONString();
+  }
+
+  public JSONObject toJsonObject() {
     JSONObject obj = new JSONObject();
     if (getPermissions() != null) {
       JSONArray permissionsJSON = new JSONArray();
@@ -190,8 +194,7 @@ public class Document {
         obj.put(listFieldEntry.getKey(), new org.json.JSONArray(listFieldEntry.getValue()));
       }
     }
-    json = obj.toJSONString();
-    return json;
+    return obj;
   }
 
   public Document addListField(String key, Collection<String> values) {

--- a/commons-search/src/test/java/org/exoplatform/commons/search/es/client/ElasticContentRequestBuilderTest.java
+++ b/commons-search/src/test/java/org/exoplatform/commons/search/es/client/ElasticContentRequestBuilderTest.java
@@ -163,6 +163,7 @@ public class ElasticContentRequestBuilderTest {
     fields.put("author", "Michael Jordan");
     when(document.getFields()).thenReturn(fields);
     when(document.toJSON()).thenCallRealMethod();
+    when(document.toJsonObject()).thenCallRealMethod();
   }
 
 }


### PR DESCRIPTION
Prior to this change, the algorithm of Json object computing was private and wasn't visible to be reused in extended Classes.