### PR TITLE
Task-49439/Task-49440 : fix accessibility criteria on login page

### DIFF
--- a/commons-extension-webapp/src/main/webapp/login/jsp/login.jsp
+++ b/commons-extension-webapp/src/main/webapp/login/jsp/login.jsp
@@ -135,16 +135,17 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
               if (errorData != null) {
 						if (org.exoplatform.web.login.LoginError.DISABLED_USER_ERROR == errorData.getCode()) {
         	 %>
-          <div class="signinFail"><i class="uiIconError"></i><%=res.getString("UILoginForm.label.DisabledUserSignin")%></div>
+          <div class="signinFail" role="alert"><i class="uiIconError"></i><%=res.getString("UILoginForm.label.DisabledUserSignin")
+          %></div>
           <%
         				}
         		  } else {%>          
-          <div class="signinFail"><i class="uiIconError"></i><%=res.getString("portal.login.SigninFail")%></div>          
+          <div class="signinFail" role="alert"><i class="uiIconError"></i><%=res.getString("portal.login.SigninFail")%></div>
           <%  }
              }%>
 			 
 		  <% if (manyUsersWithSameEmailError) {%>          
-			   <div class="signinFail"><i class="uiIconError"></i><%=res.getString("portal.login.ManyUsersWithSameEmail")%></div>          
+			   <div class="signinFail" role="alert"><i class="uiIconError"></i><%=res.getString("portal.login.ManyUsersWithSameEmail")%></div>
           <% } %>
 			 
 				</div>
@@ -158,10 +159,19 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 
                 <div class="userCredentials">
                   <span class="iconUser"></span>
-                  <input  tabindex="1" id="username" name="username" type="text" value="<%=StringEscapeUtils.escapeHtml(email)%>" placeholder="<%=res.getString("portal.login.Username")%>">                </div>
+                  <input  tabindex="1" id="username" name="username"
+                    type="text"
+                    value="<%=StringEscapeUtils.escapeHtml(email)%>"
+                    placeholder="<%=res.getString("portal.login.Username")%> *"
+                    aria-required="true">
+                </div>
                 <div class="userCredentials">
                   <span class="iconPswrd"></span>
-                  <input  tabindex="2"  type="password" id="password" name="password" placeholder="<%=res.getString("portal.login.Password")%>">
+                  <input  tabindex="2"
+                    type="password" id="password"
+                    name="password"
+                    placeholder="<%=res.getString("portal.login.Password")%> *"
+                    aria-required="true">
                 </div>
 
                 <div class="rememberContent">


### PR DESCRIPTION
Task-49439 : Accessibility : there is no role on error message on login page

Before this fix, error messages on login page havent a role, and so it was not respect the criteria 7.5.2 of RGAA rules (https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-7-5)
This commit add the role on error message of login page

Task-49440 : A11N : Add the information that the login and password fields are mandatory

Before this commit, information that login and password fiels are mandatory were missing. So, the criteria 11.10 from RGAA is not validated (https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-11-10).
This fix add the aria tag "aria-required=true on login and password field for the criteria 11.10.1, and to respect the criteria  11.10.2, it also add the character * in fields to show that it is mandatory