### PR TITLE
Task-49272: Override some styles to fix display ckeditor dialog

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/dialog/styles/dialog.css
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/dialog/styles/dialog.css
@@ -3,13 +3,13 @@
 }
 
 .cke_dialog_container {
-	position: fixed;
+	position: fixed !important;
 	overflow-y: auto;
 	overflow-x: auto;
-	width: 100%;
+	width: 100% !important;
 	height: 100%;
-	top: 0;
-	left: 0;
+	top: -1px !important;
+	left: -1px !important;
 	z-index: 10010;
 	background: none;
 	max-width: 100%;
@@ -17,4 +17,43 @@
 
 .simpleLinkDialog > .cke_dialog {
 	position: relative !important;
+}
+input#cke_61_textInput {
+	width: 100%;
+}
+
+textarea#cke_58_textarea {
+	border: Solid 1px #e1e8ee;
+	box-shadow: none;
+	width: 100%;
+	height: 40px;
+	resize: none;
+	padding: 9px 0;
+}
+@media (min-width: 768px) and (max-width: 1024px) {
+	.btn.btn-primary, .btn-primary {
+		border: none !important;
+		box-shadow: none !important;
+		padding: 10px 20px !important;
+	}
+	body .btn {
+		padding: 9px 20px !important;
+		box-shadow: none !important;
+		box-sizing: border-box !important;
+	}
+	.uiPopup {
+		margin: auto !important;
+		width: 100% !important;
+	}
+	.uiPopup .cke_dialog {
+		left: auto !important;
+		top: auto !important;
+		right: auto !important;
+		bottom: auto !important;
+		z-index: 10000 !important;
+		position: relative !important;
+	}
+	.uiPopupWrapper {
+		z-index: 0 !important;
+	}
 }


### PR DESCRIPTION
Prior to this change, the ckeditor dialog isn't displayed well, this is due to overriding styles from `core.css`.
In order to solve this problem, we add a specific style to dialog to override previous styling from (core and enterprise).