### PR TITLE
Task-50376_50599: Allow to send notifications to internal users only and add the possibility to exclude users.

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/NotificationInfo.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/NotificationInfo.java
@@ -29,6 +29,8 @@ public class NotificationInfo {
 
   public static final String        FOR_ALL_USER   = "&forAllUser";
 
+  public static final String        FOR_ALL_INTERNAL_USER   = "&forAllInternalUsers";
+
   private static IDGeneratorService idGeneratorService;
 
   private String                    id;
@@ -44,6 +46,8 @@ public class NotificationInfo {
   private Map<String, String>       ownerParameter = new HashMap<>();
 
   private List<String>              sendToUserIds  = new ArrayList<>();
+
+  private List<String>              excludedUsersIds  = new ArrayList<>();
 
   // list users send by frequency
   private String[]                  sendToDaily;
@@ -101,6 +105,22 @@ public class NotificationInfo {
   public boolean isSendAll() {
     return ArrayUtils.contains(sendToDaily, FOR_ALL_USER) ||
         ArrayUtils.contains(sendToWeekly, FOR_ALL_USER);
+  }
+
+  public boolean isSendAllInternals() {
+    return ArrayUtils.contains(sendToDaily, FOR_ALL_INTERNAL_USER) ||
+        ArrayUtils.contains(sendToWeekly, FOR_ALL_INTERNAL_USER);
+  }
+
+  public NotificationInfo setSendAllInternals(boolean isSendAllInternals) {
+    if (isSendAllInternals) {
+      setSendToDaily(new String[] { FOR_ALL_INTERNAL_USER });
+      setSendToWeekly(new String[] { FOR_ALL_INTERNAL_USER });
+    } else {
+      removeOnSendToDaily(FOR_ALL_INTERNAL_USER);
+      removeOnSendToWeekly(FOR_ALL_INTERNAL_USER);
+    }
+    return this;
   }
 
   public boolean isUpdate() {
@@ -211,12 +231,30 @@ public class NotificationInfo {
     return this;
   }
 
+  public List<String> getExcludedUsersIds() {
+    return excludedUsersIds;
+  }
+
   public NotificationInfo to(String sendToUserId) {
     this.sendToUserIds.add(sendToUserId);
     if (to == null) {
       to = sendToUserId;
     }
     return this;
+  }
+
+  public NotificationInfo exclude(List<String> excludedUsersIds) {
+    this.excludedUsersIds = excludedUsersIds;
+    return this;
+  }
+
+  public NotificationInfo exclude(String excludedUserId) {
+    this.excludedUsersIds.add(excludedUserId);
+    return this;
+  }
+
+  public boolean isExcluded(String userId) {
+    return excludedUsersIds.contains(userId);
   }
 
   /**

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/NotificationServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/NotificationServiceImpl.java
@@ -20,6 +20,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang.StringUtils;
 
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.channel.AbstractChannel;
@@ -47,6 +50,8 @@ import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.UserProfile;
 
 public class NotificationServiceImpl extends AbstractService implements NotificationService {
   private static final Log                 LOG = ExoLogger.getLogger(NotificationServiceImpl.class);
@@ -66,13 +71,18 @@ public class NotificationServiceImpl extends AbstractService implements Notifica
   /** */
   private final ChannelManager             channelManager;
 
+  /** */
+  private final OrganizationService          organizationService;
+
   public NotificationServiceImpl(ChannelManager channelManager,
                                  UserSettingService userService,
+                                 OrganizationService organizationService,
                                  DigestorService digestorService,
                                  MailNotificationStorage storage,
                                  NotificationContextFactory notificationContextFactory) {
     this.userService = userService;
     this.digestorService = digestorService;
+    this.organizationService = organizationService;
     this.storage = storage;
     this.notificationContextFactory = notificationContextFactory;
     this.channelManager = channelManager;
@@ -102,13 +112,29 @@ public class NotificationServiceImpl extends AbstractService implements Notifica
       }
 
       AbstractNotificationLifecycle lifecycle = channelManager.getLifecycle(ChannelKey.key(channel.getId()));
-      if (notification.isSendAll()) {
+      if (notification.isSendAll() || notification.isSendAllInternals()) {
         SettingService settingService = CommonsUtils.getService(SettingService.class);
         long usersCount = settingService.countContextsByType(Context.USER.getName());
         int maxResults = 100;
         for (int i = 0; i < usersCount; i += maxResults) {
           List<String> users = settingService.getContextNamesByType(Context.USER.getName(), i, maxResults);
-          lifecycle.process(ctx, users.toArray(new String[users.size()]));
+          if (notification.isSendAllInternals()) {
+            users = users.stream().filter(userId -> {
+              // Filter on external users
+              try {
+                UserProfile userProfile = organizationService.getUserProfileHandler().findUserProfileByName(userId);
+                return userProfile != null && !StringUtils.equals(userProfile.getAttribute("external"), "true");
+              } catch (Exception e) {
+                return false;
+              }
+            }).collect(Collectors.toList());
+          }
+          if (!notification.getExcludedUsersIds().isEmpty()) {
+            users = users.stream().filter(userId -> !notification.isExcluded(userId)).collect(Collectors.toList());
+          }
+          if (!users.isEmpty()) {
+            lifecycle.process(ctx, users.toArray(new String[users.size()]));
+          }
         }
       } else {
         if (notification.getSendToUserIds() == null || notification.getSendToUserIds().isEmpty()) {


### PR DESCRIPTION
Prior to this change, we can't send a notification to internal users only and it is not possible to exclude users. After this change, it will be possible to send notifications for internal users only and to exclude some users
(cherry picked from commit 5707f9c1cdba9f254f231f15ceffa583ddc2e280)