### PR TITLE
Task-51620 : Add aria-label on connect button on login page (#266)

### DIFF
--- a/commons-extension-webapp/src/main/webapp/login/jsp/login.jsp
+++ b/commons-extension-webapp/src/main/webapp/login/jsp/login.jsp
@@ -188,7 +188,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
 
                 </script>
 				<div id="UIPortalLoginFormAction" class="loginButton">
-					<button class="button" tabindex="4"  onclick="login();"><%=res.getString("portal.login.Signin")%></button>
+					<button class="button" tabindex="4" aria-label="<%=res.getString("portal.login.Signin")%>" onclick="login();"><%=res.getString("portal.login.Signin")%></button>
 				</div>
                 <div class="forgotPasswordClass">
                     <a href="<%= contextPath + forgotPasswordPath %>" title="<%=res.getString("gatein.forgotPassword.loginLinkTitle")%>"><%=res.getString("gatein.forgotPassword.loginLinkTitle")%></a>


### PR DESCRIPTION
Before this fix, the connect button on login page does not respect RGAA Criteria 11.9 :
https://www.numerique.gouv.fr/publications/rgaa-accessibilite/methode-rgaa/criteres/#crit-11-9
This commit add the aria-label attribute on this button to make it compliant