### PR TITLE
Task-52469 : on ckEditor popup, the close button is positionned outsi…

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/skins/moono-exo/less/dialog.less
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/skins/moono-exo/less/dialog.less
@@ -12,6 +12,7 @@ For licensing, see LICENSE.md or http://ckeditor.com/license
   background: #ffffff;
   box-shadow: 0 2px 3px rgba(0, 0, 0, 0.25);
   border-radius: 4px;
+  position:relative;
 }
 
 .cke_dialog strong {


### PR DESCRIPTION
…de of the popup

Before this fix, when opening a ckeditor popup like InsertImage, the close popup of the popup is positionned outside of the popup, in the top left corner of the page.
This is due to the last ckEditor update, which removed positionning of html class cke_dialog_body.
This commit add the position:relative on cke_dialog_body class, so that the close button is correctly positionned.