### PR TITLE
MAINT-52374: Allow iframe tags in the sanitized content of the custom directive v-sanitized-html

### DIFF
--- a/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -531,13 +531,23 @@
         (function() {
           <include>/javascript/purify.min.js</include>
           Vue.directive('sanitized-html',function(el, binding) {
-          el.innerHTML = DOMPurify.sanitize(Autolinker.link(binding.value, {newWindow: true}), {USE_PROFILES: {html: true},ADD_ATTR: ['target']});
+          el.innerHTML = DOMPurify.sanitize(Autolinker.link(binding.value, {newWindow: true}),
+                         {USE_PROFILES: {html: true}, ADD_TAGS: ["iframe"], ADD_ATTR: ['target','allow', 'allowfullscreen', 'frameborder', 'scrolling']});
             DOMPurify.addHook('afterSanitizeAttributes', function (node) {
             // add noopener attribute to external links to eliminate vulnerabilities
-            if ('target' in node) {
-             node.setAttribute('rel', 'noopener');
+             if ('target' in node) {
+               node.setAttribute('rel', 'noopener');
+             }
+            });
+            DOMPurify.addHook('uponSanitizeElement', function (node) {
+             if (node.tagName === 'iframe') {
+               const src = node.getAttribute('src') || '';
+               if (!src.startsWith('https://www.youtube.com/embed/')
+                           || !src.startsWith('https://player.vimeo.com/video/') || !src.startsWith('https://www.dailymotion.com/embed/video/')) {
+                 return node.parentNode?.removeChild(node);
+               }
             }
-          });
+            });
           })
           })();
       </adapter>


### PR DESCRIPTION
**ISSUE**: When using v-sanitized-html directive the `iframe` tags used in the embedded news content videos are removed from the html content because of the default `DOMPurify` sanitization settings which doesn't allow iframes
**FIX**: This Fix should allow `iframe` tags and its used tags and for a secure embed i added a controle on the src attribute to allow only youtube, vimeo and dailymotion embedded videos