### PR TITLE
TASK-38380: When pasting a YouTube link, a white margin appears and the cross button delete the typed text.

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/autoembed/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/autoembed/plugin.js
@@ -132,7 +132,7 @@
 					var last = editable.getLast();
 					insertRange.setEndAfter( last );
 					// add three lines break and add close preview button
-					wrapper.$.innerHTML = "<br><br><br><div style="+"'display:flex; background-color:#e1e8ee;'"+"><div style="+"width:100%"+"><br></div><div><button style="+"'cursor:pointer; border:none; background:none; color:#A8B3C5; padding:5px 8px 7px'"+">X</button></div></div>"+wrapper.$.innerHTML;
+					wrapper.$.innerHTML = "<br><div style="+"'display:flex; background-color:#e1e8ee;'"+"><div style="+"width:100%"+"><br></div><div><button style="+"'cursor:pointer; border:none; background:none; color:#A8B3C5; padding:5px 8px 7px'"+">X</button></div></div>"+wrapper.$.innerHTML;
 					editable.insertElement( wrapper, insertRange );
 					// eXo customization - end
 
@@ -161,7 +161,7 @@
 						lastElement.remove();
 						// add event of close preview button
 						editor.editable().findOne( 'button' ).on( 'click', function( ev ) {
-							editor.editable().findOne( 'div' ).remove();
+							editor.editable().findOne( 'div.cke_widget_wrapper' ).remove();
 						});
 
 					}

--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/autoembed/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/autoembed/plugin.js
@@ -131,7 +131,7 @@
 					// add this line for add the preview in the end of content
 					var last = editable.getLast();
 					insertRange.setEndAfter( last );
-					// add three lines break and add close preview button
+					
 					wrapper.$.innerHTML = "<br><div style="+"'display:flex; background-color:#e1e8ee;'"+"><div style="+"width:100%"+"><br></div><div><button style="+"'cursor:pointer; border:none; background:none; color:#A8B3C5; padding:5px 8px 7px'"+">X</button></div></div>"+wrapper.$.innerHTML;
 					editable.insertElement( wrapper, insertRange );
 					// eXo customization - end


### PR DESCRIPTION
ISSUES : When pasting a YouTube link, a white margin appears between the text and the embedded image and the cross (X) button delete the typed text.
FIX :  When pasting a YouTube link,the first problem that a white margin appears between the text and the embedded image and it fixed by removing the three lines break after the embed link and the second problem is when clicking on the cross (X) of the embedded image, the typed text is deleted first and not the embedded image and this was corrected by adding the div class to the findOne() function that the cross button should delete.
