### PR TITLE
Fix build fail

### DIFF
--- a/commons-component-common/src/test/java/org/exoplatform/commons/embedder/EmbedderTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/embedder/EmbedderTest.java
@@ -107,17 +107,17 @@ public class EmbedderTest extends BaseCommonsTestCase {
   }
 
   public void testVimeoShare() {
-    String dailyMotion = "http://vimeo.com/72407771";
+    String dailyMotion = "http://vimeo.com/33031367";
     // Vimeo oembed response
     embedder = EmbedderFactory.getInstance(dailyMotion);
     ExoMedia vimeoObj = embedder.getExoMedia();
     if(vimeoObj == null) {
       LOG.warn("Can't connect to vimeo"); 
     }
-    assertRetrurnedData("http://vimeo.com/72407771");
-    assertRetrurnedData("https://vimeo.com/72407771");
-    assertRetrurnedData("http://player.vimeo.com/video/72407771");
-    assertRetrurnedData("https://player.vimeo.com/video/72407771");
+    assertRetrurnedData("http://vimeo.com/33031367");
+    assertRetrurnedData("https://vimeo.com/33031367");
+    assertRetrurnedData("http://player.vimeo.com/video/33031367");
+    assertRetrurnedData("https://player.vimeo.com/video/33031367");
   }
 
   /**


### PR DESCRIPTION
ISSUE: Old used unaccessible vimeo video url caused a unit test testVimeoShare fail
FIX: Add new accessible video url for the unit test