### PR TITLE
Task-54884 : External users receive notification of published news from a space of which they are not a member

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/NotificationServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/NotificationServiceImpl.java
@@ -123,7 +123,7 @@ public class NotificationServiceImpl extends AbstractService implements Notifica
               // Filter on external users
               try {
                 UserProfile userProfile = organizationService.getUserProfileHandler().findUserProfileByName(userId);
-                return userProfile != null && !StringUtils.equals(userProfile.getAttribute(UserProfile.OTHER_KEYS[2]), "true");
+                return userProfile == null || !StringUtils.equals(userProfile.getAttribute(UserProfile.OTHER_KEYS[2]), "true");
               } catch (Exception e) {
                 return false;
               }

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/NotificationServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/NotificationServiceImpl.java
@@ -123,7 +123,7 @@ public class NotificationServiceImpl extends AbstractService implements Notifica
               // Filter on external users
               try {
                 UserProfile userProfile = organizationService.getUserProfileHandler().findUserProfileByName(userId);
-                return userProfile != null && !StringUtils.equals(userProfile.getAttribute("external"), "true");
+                return userProfile != null && !StringUtils.equals(userProfile.getAttribute(UserProfile.OTHER_KEYS[2]), "true");
               } catch (Exception e) {
                 return false;
               }


### PR DESCRIPTION
Before this fix, the external status is tested in gatein profile, but is only present in social profile.
This commit update the listener which update the gatein profile when the social profile change to take care of this modification.
After that, as the external info is present in gatein profile, notification will be able to check it correctly.