### PR TITLE
Suppress warning when using Elasticsearch 7.17 (expected one)

### DIFF
--- a/commons-search/src/main/resources/conf/portal/configuration.xml
+++ b/commons-search/src/main/resources/conf/portal/configuration.xml
@@ -36,7 +36,7 @@
     <init-params>
       <value-param>
         <name>es.version</name>
-        <value>${exo.es.version.minor:7.13}</value>
+        <value>${exo.es.version.minor:7.17}</value>
       </value-param>
     </init-params>
   </component>


### PR DESCRIPTION
Prior to this change, when using ES `7.17` (the supported version), an error message appears in the server startup logs instructing the user to submit the correct version of ES.
This PR makes sure to put the correct value for Meeds `1.3+` in order to suppress this error message.