### PR TITLE
Task-56489 : Possible NPE exception when sending mail

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/MessageInfo.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/MessageInfo.java
@@ -193,7 +193,9 @@ public class MessageInfo {
     message.setTo(to);
     message.setSubject(subject);
     message.setBody(body + ((footer != null && footer.length() > 0) ? footer : ""));
-    this.attachments.stream().forEach(message::addAttachment);
+    if (attachments != null) {
+      this.attachments.stream().forEach(message::addAttachment);
+    }
     return message;
   }
 


### PR DESCRIPTION
Before this fix, if makeNotification is called without calling addAttachment, the attachements variable is null, and generate a NPE.
This commit correctly test the map nullity.