### PR TITLE
Task-55861: Update ck-editor to 4.16.0 (#161)

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
@@ -20,7 +20,7 @@ CKEDITOR.editorConfig = function( config ) {
 
     // %REMOVE_START%
     // The configuration options below are needed when running CKEditor from source files.
-    config.plugins = 'dialogui,dialog,about,a11yhelp,basicstyles,blockquote,panel,floatpanel,button,toolbar,enterkey,entities,popup,filebrowser,floatingspace,listblock,richcombo,format,horizontalrule,htmlwriter,wysiwygarea,indent,indentlist,fakeobjects,list,maximize,removeformat,showborders,sourcearea,specialchar,scayt,stylescombo,tab,table,notification,notificationaggregator,filetools,undo,wsc,panelbutton,colorbutton,autogrow,confighelper,uploadwidget,imageresize,confirmBeforeReload,autoembed,embedsemantic';
+    config.plugins = 'dialogui,dialog,about,a11yhelp,basicstyles,blockquote,panel,floatpanel,button,toolbar,enterkey,entities,popup,filebrowser,floatingspace,listblock,richcombo,format,horizontalrule,htmlwriter,wysiwygarea,indent,indentlist,fakeobjects,list,maximize,removeformat,showborders,sourcearea,specialchar,scayt,stylescombo,tab,table,notification,notificationaggregator,filetools,undo,wsc,autogrow,confighelper,uploadwidget,imageresize,confirmBeforeReload,autoembed,embedsemantic';
 
     CKEDITOR.plugins.addExternal('simpleLink','/commons-extension/eXoPlugins/simpleLink/','plugin.js');
     CKEDITOR.plugins.addExternal('simpleImage','/commons-extension/eXoPlugins/simpleImage/','plugin.js');


### PR DESCRIPTION
Since version ` 4.8 `of CKEditor, the `uploadimage` plugin is automatically enabled in CKEditor [*REF*](https://github.com/Meeds-io/commons/blob/836f2619ec02707594086f31e8d7c1441e073541/commons-extension-webapp/src/main/webapp/ckeditor/CHANGES.md#ckeditor-48), but in our case, we use this plugin with some modification, so my fix is to update CKEditor to `4.16.0` and disabled the `uploadimage` plugin by default