### PR TITLE
Task-55861 : Update ck-editor to 4.16.0 (#161)

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/dialog/styles/dialog.css
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/dialog/styles/dialog.css
@@ -3,13 +3,13 @@
 }
 
 .cke_dialog_container {
-	position: fixed;
+	position: fixed !important;
 	overflow-y: auto;
 	overflow-x: auto;
-	width: 100%;
+	width: 100% !important;
 	height: 100%;
-	top: 0;
-	left: 0;
+	top: -1px !important;
+	left: -1px !important;
 	z-index: 10010;
 	background: none;
 	max-width: 100%;
@@ -17,4 +17,43 @@
 
 .simpleLinkDialog > .cke_dialog {
 	position: relative !important;
+}
+input#cke_61_textInput {
+	width: 100%;
+}
+
+textarea#cke_58_textarea {
+	border: Solid 1px #e1e8ee;
+	box-shadow: none;
+	width: 100%;
+	height: 40px;
+	resize: none;
+	padding: 9px 0;
+}
+@media (min-width: 768px) and (max-width: 1024px) {
+	.btn.btn-primary, .btn-primary {
+		border: none !important;
+		box-shadow: none !important;
+		padding: 10px 20px !important;
+	}
+	body .btn {
+		padding: 9px 20px !important;
+		box-shadow: none !important;
+		box-sizing: border-box !important;
+	}
+	.uiPopup {
+		margin: auto !important;
+		width: 100% !important;
+	}
+	.uiPopup .cke_dialog {
+		left: auto !important;
+		top: auto !important;
+		right: auto !important;
+		bottom: auto !important;
+		z-index: 10000 !important;
+		position: relative !important;
+	}
+	.uiPopupWrapper {
+		z-index: 0 !important;
+	}
 }

--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
@@ -20,7 +20,7 @@ CKEDITOR.editorConfig = function( config ) {
 
     // %REMOVE_START%
     // The configuration options below are needed when running CKEditor from source files.
-    config.plugins = 'dialogui,dialog,about,a11yhelp,basicstyles,blockquote,panel,floatpanel,button,toolbar,enterkey,entities,popup,filebrowser,floatingspace,listblock,richcombo,format,horizontalrule,htmlwriter,wysiwygarea,indent,indentlist,fakeobjects,list,maximize,removeformat,showborders,sourcearea,specialchar,scayt,stylescombo,tab,table,notification,notificationaggregator,filetools,undo,wsc,panelbutton,colorbutton,autogrow,confighelper,uploadwidget,imageresize,confirmBeforeReload,autoembed,embedsemantic';
+    config.plugins = 'dialogui,dialog,about,a11yhelp,basicstyles,blockquote,panel,floatpanel,button,toolbar,enterkey,entities,popup,filebrowser,floatingspace,listblock,richcombo,format,horizontalrule,htmlwriter,wysiwygarea,indent,indentlist,fakeobjects,list,maximize,removeformat,showborders,sourcearea,specialchar,scayt,stylescombo,tab,table,notification,notificationaggregator,filetools,undo,wsc,autogrow,confighelper,uploadwidget,imageresize,confirmBeforeReload,autoembed,embedsemantic';
 
     CKEDITOR.plugins.addExternal('simpleLink','/commons-extension/eXoPlugins/simpleLink/','plugin.js');
     CKEDITOR.plugins.addExternal('simpleImage','/commons-extension/eXoPlugins/simpleImage/','plugin.js');


### PR DESCRIPTION
Since version ` 4.8 `of CKEditor, the `uploadimage` plugin is automatically enabled in CKEditor [*REF*](https://github.com/Meeds-io/commons/blob/836f2619ec02707594086f31e8d7c1441e073541/commons-extension-webapp/src/main/webapp/ckeditor/CHANGES.md#ckeditor-48), but in our case, we use this plugin with some modification, so my fix is to update CKEditor to `4.16.0` and disabled the `uploadimage` plugin by default