### PR TITLE
TASK-56611: Hyperlink  is not opened and nothing happens (#316)

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
@@ -60,8 +60,7 @@ abstract public class HTMLSanitizer {
 
   private static final Pattern                                                ONSITE_URL               = Pattern.compile("(?:[\\p{L}\\p{N} \\\\\\.\\#@\\$%\\+&;\\-_~,\\?=/!:]+|\\#(\\w)+)");
 
-  private static final Pattern                                                OFFSITE_URL              = Pattern.compile("\\s*(?:(?:ht|f)tps?://|mailto:)[\\p{L}\\p{N}]"
-                                                                                                           + "[\\p{L}\\p{N} \\p{Zs}\\.\\#@\\$%\\+&;:\\-_~,\\?=/!\\(\\)\\*]*+\\s*");
+  private static final Pattern                                                OFFSITE_URL              = Pattern.compile("\\s*(?:(?:ht|f)tps?:\\/\\/|mailto:)[\\p{L}\\p{N}][\\p{L}\\p{N} \\p{Zs}\\.\\[\\]\\#@\\$%\\+&;:\\-_~,\\?=\\/!\\(\\)\\*]*+\\s*");
 
   private static final Pattern                                                NUMBER                   = Pattern.compile("[+-]?(?:(?:[0-9]+(?:\\.[0-9]*)?)|\\.[0-9]+)");
 

--- a/commons-component-common/src/test/java/org/exoplatform/commons/utils/HTMLSanitizerTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/utils/HTMLSanitizerTest.java
@@ -19,6 +19,7 @@
 package org.exoplatform.commons.utils;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -104,5 +105,16 @@ public class HTMLSanitizerTest {
     String input = "<a class=\"class\" href=\"url\" target=\"_blank\">link</a>";
     String sanitized = HTMLSanitizer.sanitize(input);
     assertEquals("<a class=\"class\" href=\"url\" target=\"_blank\" rel=\"nofollow noopener noreferrer\">link</a>", sanitized);
+  }
+  @Test
+  public void testAllowedSpecialCharactersLinks(){
+    String input = "https://www.economie.gouv.fr/entreprises/changement-janvier-2022?xtor=ES-29-[BIE_292_20220106]-20220106-[https://www.economie.gouv.fr/entreprises/changement-janvier-2022]";
+    String sanitized = null;
+    try {
+      sanitized = HTMLSanitizer.sanitize(input);
+    } catch (Exception e) {
+      fail();
+    }
+    assertEquals("https://www.economie.gouv.fr/entreprises/changement-janvier-2022?xtor&#61;ES-29-[BIE_292_20220106]-20220106-[https://www.economie.gouv.fr/entreprises/changement-janvier-2022]", sanitized);
   }
 }


### PR DESCRIPTION
Prior to this change, when add an article then add hyperLink in the body via the icon link , in the link popup add the text and enter the complex link (ex: https://www.economie.gouv.fr/entreprises/changement-janvier-2022?xtor=ES-29-[BIE_292_20220106]-20220106-[https://www.economie.gouv.fr/entreprises/changement-janvier-2022] then post that article , so the problem when i click in hyperlink.
This is due to changing with link is not redirected in the link so href is empty ,
After this change, we ensure that when click in hyperlink in the body , it redirected in the link , so it work correctly.