### PR TITLE
Task:55792:  When clicking on a push notif ==> CKeditor options block appear which hide the message that i received 

### DIFF
--- a/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -169,6 +169,7 @@
 				<include>/ckeditor/ckeditor.js</include>
 				// force compatible version in any case to make sure the editor will initialize
 				CKEDITOR.env.isCompatible = true;
+        CKEDITOR.disableAutoInline = true;
         // Force to update plugin resources each eXo version
         CKEDITOR.timestamp = eXo.env.client.assetsVersion;
 				<include>/ckeditor/adapters/jquery.js</include>


### PR DESCRIPTION
ISSUE: in some cases the ckeditor will be injected in all elements with the contenteditable attribue set to true
FIX: explicitly set the disableAutoInline attribute in the ckeditor to true