### PR TITLE
TASK-57166: Fix all the written after tag is considered as a tag

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
@@ -342,6 +342,8 @@ abstract public class HTMLSanitizer {
                                                                                                                                 .onElements("iframe")
                                                                                                                                 .allowAttributes("frameborder")
                                                                                                                                 .onElements("iframe")
+                                                                                                                                .allowAttributes("contenteditable")
+                                                                                                                                .globally()
                                                                                                                                 .toFactory();
 
   /**


### PR DESCRIPTION
ISSUES : when update a post that contient a tag , we reselect it from the suggestion and add a white space ,all the written after that tag is colored in blue like if it was a tag
FIX : the problem is that when we create a message that contains a tag, the HtmlSanitizer removes the contenteditable attribute that is not allowed. fixed by configure allowed HTML attribute  contenteditable through the property AllowedAttributes