### PR TITLE
TASK-57151 Enhance Tag Suggester UX on CKEditor

### DIFF
--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
@@ -374,7 +374,7 @@ var Controller,
 
 Controller = (function() {
   Controller.prototype.uid = function() {
-    return (Math.random().toString(16) + "000000000").substr(2, 8) + (new Date().getTime());
+    return Math.random().toString(16).substr(2);
   };
 
   function Controller(app, at1) {

--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/tag.suggester.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/tag.suggester.js
@@ -159,7 +159,9 @@
       }
     };
     app.settings = settings;
-    app.atWho = $this.atwho(app.settings);
+    window.setTimeout(() => {
+      app.atWho = $this.atwho(app.settings);
+    }, 200);
   };
 
   return $;


### PR DESCRIPTION
Prior to this change, sometimes the Tag suggester isn't displayed when displaying CKEditor. This change ensures to use a unique UUID for suggesters to avoid collision with Identity Suggester. In addition, premature suggester initialization, the CKEDitor plugin will initialize the Tag Suggester in deferred mode using .