### PR TITLE
TASK-57576: Issue when insert a tag html content by tags suggester inside the composer

### DIFF
--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
@@ -491,6 +491,9 @@ Controller = (function() {
       this.expectedQueryCBId = null;
       return query;
     }
+    if (query.el.attr('class') !== 'atwho-query') {
+      return;
+    }
     this.app.setContextFor(this.at);
     if (wait = this.getOpt('delay')) {
       this._delayLookUp(query, wait);


### PR DESCRIPTION
Prior to this change, when edit a short message that contains a tag, the tag suggester container is wrongly positioned when press backspace.
This PR should make sure to trigger the suggester view only when the user click on the already filled tag text to avoid such behavior.