### PR TITLE
TASK-56781 Allow to use v-identity-provider in HTMLSanitizer

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
@@ -344,6 +344,8 @@ abstract public class HTMLSanitizer {
                                                                                                                                 .onElements("iframe")
                                                                                                                                 .allowAttributes("contenteditable")
                                                                                                                                 .globally()
+                                                                                                                                .allowAttributes("v-identity-popover")
+                                                                                                                                .globally()
                                                                                                                                 .toFactory();
 
   /**


### PR DESCRIPTION
Prior to this change, the HTMLSanitizer utils doesn't allow to add specific Vue attributes on rendered HTML in activity stream. This change will allow to add a specific attribute (v-identity-popover) that will be added in suggested users inside activity/comment body.