### PR TITLE
TASK-51495: Fix Copy and paste a document from Google Doc into an article

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/config.js
@@ -30,6 +30,7 @@ CKEDITOR.editorConfig = function( config ) {
     CKEDITOR.plugins.addExternal('autoembed','/commons-extension/eXoPlugins/autoembed/','plugin.js');
     CKEDITOR.plugins.addExternal('embedsemantic','/commons-extension/eXoPlugins/embedsemantic/','plugin.js');
     CKEDITOR.plugins.addExternal('tagSuggester','/commons-extension/eXoPlugins/tagSuggester/','plugin.js');
+    CKEDITOR.plugins.addExternal('googleDocPastePlugin','/commons-extension/eXoPlugins/googleDocPastePlugin/','plugin.js')
 
     config.extraPlugins = 'simpleLink,suggester,hideBottomToolbar';
     config.skin = 'moono-exo,/commons-extension/ckeditor/skins/moono-exo/';

--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/googleDocPastePlugin/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/googleDocPastePlugin/plugin.js
@@ -1,0 +1,71 @@
+(function () {
+    'use strict';
+    CKEDITOR.plugins.add('googleDocPastePlugin', {
+        requires: 'clipboard',
+        init: function (editor) {
+            editor.on('paste', function (evt) {
+                if ("data" in evt && "dataValue" in evt.data && evt.data.dataValue.indexOf("docs-internal-guid") > -1 && "dataTransfer" in evt.data && "_" in evt.data.dataTransfer && "data" in evt.data.dataTransfer._ && "text/html" in evt.data.dataTransfer._.data) {
+                    evt.data.dataValue = formatting(evt.data.dataTransfer._.data['text/html']);
+                }
+            });
+        }
+    });
+})();
+
+function recursiveFormatting(context) {
+    for(const childNode of context.childNodes){
+        var clonedEle, ele;
+      //for italicity
+        if (childNode.style.fontStyle !== "") {
+            if (childNode.style.fontStyle === "italic") {
+                childNode.style.fontStyle = null;
+                clonedEle = childNode.cloneNode(true);
+                ele = document.createElement("em");
+                ele.append(clonedEle)
+                context.replaceChild(ele, childNode);
+            } else {
+                childNode.style.fontStyle = null;
+            }
+        }
+     //for underline
+        if (childNode.style.textDecoration !== "") {
+            if (childNode.style.textDecoration === "underline") {
+                childNode.style.textDecoration = null;
+                clonedEle = childNode.cloneNode(true);
+                ele = document.createElement("u");
+                ele.append(clonedEle)
+                context.replaceChild(ele, childNode);
+            } else {
+                childNode.style.textDecoration = null;
+            }
+        }
+       //for bold
+        if (childNode.style.fontWeight !== "") {
+            if (childNode.style.fontWeight > "400") {
+                childNode.style.fontWeight = null;
+                clonedEle = childNode.cloneNode(true);
+                ele = document.createElement("strong");
+                ele.append(clonedEle)
+                context.replaceChild(ele, childNode);
+            } else {
+                childNode.style.fontWeight = null;
+            }
+        }
+        if (childNode.children.length > 0) {
+            recursiveFormatting(childNode);
+        }
+    }
+}
+
+
+function formatting(str) {
+    var parent = document.createElement("div");
+    var parentCopy = document.createElement("div");
+    parentCopy.innerHTML = str;
+    var len = parentCopy.childNodes[0].children.length;
+    for(var i = 0; i<len; i++ ) {
+        parent.appendChild(parentCopy.childNodes[0].children[i].cloneNode(true));
+    }
+    recursiveFormatting (parent);
+    return parent.innerHTML;
+}


### PR DESCRIPTION
ISSUES : When we copy a text from a google Doc and paste it in article ,The content is bolded automatically  .
FIX : Problem is that pasting content from Google Docs to ckeditor breaks the formatting of the text, fixed by adding the plugin googleDocPastePlugin which allows pasting content from google docs to ckeditor in the same format and allows text formatting (bold, underline, italics, color)
(cherry picked from commit eb8bb8fe1fea5d5c9ad42fa5c13eb4cf539acf1a)