### PR TITLE
MEED-298 Fix Suggester Menu position when scrollbar is displayed in CKEditor

### DIFF
--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
@@ -1009,6 +1009,11 @@ View = (function() {
     if (rect.left > (overflowOffset = $(_window).width() - this.$el.width() - 5)) {
       rect.left = overflowOffset;
     }
+    const scrollingElement = window?.CKEDITOR?.currentInstance?.document?.$?.scrollingElement;
+    if (scrollingElement) {
+      rect.bottom -= scrollingElement.scrollTop;
+      rect.left -= scrollingElement.scrollLeft;
+    }
     offset = {
       left: rect.left,
       top: rect.bottom

--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/suggester/jquery.atwho.js
@@ -1009,7 +1009,11 @@ View = (function() {
     if (rect.left > (overflowOffset = $(_window).width() - this.$el.width() - 5)) {
       rect.left = overflowOffset;
     }
-    const scrollingElement = window?.CKEDITOR?.currentInstance?.document?.$?.scrollingElement;
+    const scrollingElement = window.CKEDITOR
+                             && window.CKEDITOR.currentInstance
+                             && window.CKEDITOR.currentInstance.document
+                             && window.CKEDITOR.currentInstance.document.$
+                             && window.CKEDITOR.currentInstance.document.$.scrollingElement;
     if (scrollingElement) {
       rect.bottom -= scrollingElement.scrollTop;
       rect.left -= scrollingElement.scrollLeft;


### PR DESCRIPTION
Prior to this change, when typing a user suggest search in a CKEditor that displays a scrollbar (long text), the Suggested users Menu position is badly displayed (bad top position). This fix ensures to compute well the top and left position of Menu to display by considering scoll position of element.