### PR TITLE
TASK-59178: Use PATCH annotation from Meeds WS implementation

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/rest/NotificationSettingsRestService.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/rest/NotificationSettingsRestService.java
@@ -29,7 +29,7 @@ import org.exoplatform.services.rest.resource.ResourceContainer;
 import org.exoplatform.services.security.ConversationState;
 
 import io.swagger.annotations.*;
-import io.swagger.jaxrs.PATCH;
+import org.exoplatform.services.rest.http.PATCH;
 
 @Path("notifications/settings")
 @Api(tags = "notifications/settings", value = "notifications/settings", description = "Managing users notifications settings") // NOSONAR

--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/rest/WebNotificationRestService.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/rest/WebNotificationRestService.java
@@ -4,8 +4,7 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
-import io.swagger.jaxrs.PATCH;
-
+import org.exoplatform.services.rest.http.PATCH;
 import java.util.List;
 
 import javax.annotation.security.RolesAllowed;


### PR DESCRIPTION
Prior to this change, All endpoints those use http patch requests are using the swagger jaxrs PATCH annotation,
This PR should use the PATCH annotation from Meeds WS implementation instead of swagger jaxrs annotation