### PR TITLE
Task-59174: Disable autoLink of email addresses

### DIFF
--- a/commons-extension-webapp/src/main/webapp/javascript/eXo/commons/ExtendedDomPurify.js
+++ b/commons-extension-webapp/src/main/webapp/javascript/eXo/commons/ExtendedDomPurify.js
@@ -20,7 +20,7 @@
   let ExtendedDomPurify = function() {
   };
   ExtendedDomPurify.prototype.purify = function(content) {
-    const pureHtml = DOMPurify.sanitize(Autolinker.link(content, { newWindow: true }), {
+    const pureHtml = DOMPurify.sanitize(Autolinker.link(content, { newWindow: true, email: false }), {
       USE_PROFILES: {
         html: true,
         SAFE_FOR_TEMPLATES: true,


### PR DESCRIPTION
Prior to this change, the email address inserted in sanitized texts is automatically clickable and opening a new tab to send a new mail. This commit will fix that by disabling autoLink for email addresses.