### PR TITLE
fix: Allow search using different metadata filter - EXO-59495 - Meeds-io/meeds#326

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/ElasticSearchServiceConnector.java
@@ -548,12 +548,13 @@ public class ElasticSearchServiceConnector extends SearchServiceConnector {
   protected String getMetadataQuery(List<ElasticSearchFilter> filters) {
 
     if (filters == null) return "";
+    StringBuilder metaQuery= new StringBuilder();
     for (ElasticSearchFilter filter: filters) {
       if (filter.getType().equals(ElasticSearchFilterType.FILTER_MATADATAS)) {
-        return filter.getValue();
+        metaQuery.append(filter.getValue());
       }
     }
-    return "";
+    return metaQuery.toString();
   }
 
   private String getFilter(ElasticSearchFilter filter) {


### PR DESCRIPTION
Prior to this fix, only one metadata type filter was allowed on elastic search,
As we have other types as tags, the method should return a string containing all provided metadata filters.