### PR TITLE
fix: Fix bad display of folder component in insert portal link popup window - EXO-58626 - Meeds-io/meeds#343

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/insertPortalLink/insertPortalLink.html
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/insertPortalLink/insertPortalLink.html
@@ -49,12 +49,12 @@
 	<body>
 		<div id="root" class="Root" style="position: relative; height: 95%; overflow: auto;padding:15px">
 			<div class="row-fluid">
-				<div class="span4">
+				<div class="span4" style="float: left; margin-right:0px" >
 					<div class="uiBox" >
 						<div class=" " id="LeftWorkspace"></div>
 					</div>
 				</div>
-				<div class="span8">
+				<div class="span8" style="float: left; margin-right:0px" >
 					<div class="displayArea uiBox" id="DisplayArea">
 						<div class="listView uiContentBox">
 					  	<table cellspacing="0" cellpadding="0" border="0" class="uiGrid table table-hover table-striped" id="ListRecords" >


### PR DESCRIPTION
Prior to this change, when browsing portal sites navigations from insert portal link ckeditor plugin, folder component is displayed in the upper right of the displayed insert portal link popup window. After this change, we have adjusted the folder component in order to be displayed at the left side of the popup.

(cherry picked from commit f52b2303a086df139e0785268b1860918df95bd3)