### PR TITLE
fix : Hide digest mail notification from notification settings menu - EXO-54929 - Meeds-io/meeds#348

### DIFF
--- a/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/notification-configuration.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/conf/commons-extension/notification-configuration.xml
@@ -157,6 +157,18 @@
   <component profiles="all">
     <type>org.exoplatform.commons.notification.cache.TemplateCaching</type>
   </component>
+
+  <component>
+    <key>DigestMailNotificationFeatureProperties</key>
+    <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
+    <init-params>
+      <properties-param>
+        <name>DigestMailNotificationFeatureProperties</name>
+        <description>Mail Digest Feature enablement flag</description>
+        <property name="exo.feature.digestMailNotification.enabled" value="${exo.feature.digestMailNotification.enabled:false}"/>
+      </properties-param>
+    </init-params>
+  </component>
   
   <!-- channel register -->
   <external-component-plugins>
@@ -213,7 +225,7 @@
           <property name="jobName" value="NotificationDailyJob"/>
           <property name="groupName" value="Notification"/>
           <property name="job" value="org.exoplatform.commons.notification.job.NotificationDailyJob"/>
-          <property name="expression" value="${exo.notification.NotificationDailyJob.expression:0 0 23 ? * *}"/><!-- Run at 11:00pm every day -->
+          <property name="expression" value="${exo.notification.NotificationDailyJob.expression:59 59 0,23 31 DEC ? 2099}"/><!-- Run at 11:00pm every day -->
         </properties-param>
       </init-params>
     </component-plugin>
@@ -229,7 +241,7 @@
           <property name="jobName" value="NotificationWeeklyJob"/>
           <property name="groupName" value="Notification"/>
           <property name="job" value="org.exoplatform.commons.notification.job.NotificationWeeklyJob"/>
-          <property name="expression" value="${exo.notification.NotificationWeeklyJob.expression:0 0 11 ? * SUN}"/><!-- Run at 11:00am every Sunday in every month -->
+          <property name="expression" value="${exo.notification.NotificationWeeklyJob.expression:59 59 0,23 31 DEC ? 2099}"/><!-- Run at 11:00am every Sunday in every month -->
         </properties-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
Prior to this change, many issues are related to digest email feature are reported and it needs to be fixed. Until re-worked this feature needs to be disabled.
After this change:

- For all users, we have hidden the digest mail notifications settings view and edit from manage notification settings with the FT flag exo.feature.digestMailNotifiaction which will be added and configured as false by default
- For old users having already enabled digestMailNotification settings, we have configured as following: "${exo.notification.NotificationDailyJob.expression:59 59 0,23 31 DEC ? 2099}" "${exo.notification.NotificationWeeklyJob.expression:59 59 0,23 31 DEC ? 2099}"
the default values of NotificationDailyJob and NotificationWeeklyJob expression properties with very distant period in order to guarantee that they will not receive digest mail notifications anymore despite their stored digestMailNotification settings as enabled (daily/weekly)