### PR TITLE
feat: stabilize commons with JDK 17 - EXO-60455 - Meeds-io/MIPs#26

### DIFF
--- a/commons-comet-webapp/pom.xml
+++ b/commons-comet-webapp/pom.xml
@@ -21,6 +21,12 @@
     <finalName>cometd</finalName>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
           <overlays>

--- a/commons-extension-webapp/pom.xml
+++ b/commons-extension-webapp/pom.xml
@@ -108,6 +108,16 @@
     <finalName>commons-extension</finalName>
     <plugins>
       <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>@{argLine} --add-opens java.base/java.util=ALL-UNNAMED</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-war-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.lesscss</groupId>
         <artifactId>lesscss-maven-plugin</artifactId>
         <executions>

--- a/commons-testing/src/main/java/org/exoplatform/commons/testing/webui/AbstractUIComponentTestCase.java
+++ b/commons-testing/src/main/java/org/exoplatform/commons/testing/webui/AbstractUIComponentTestCase.java
@@ -23,7 +23,7 @@ import org.exoplatform.webui.core.UIComponent;
 /**
  * Convenience TestCase made to test UIComponent classes.
  * Creates a new UIComponent for each call to {@link #setUp()}
- * @param T type of the UIComponent
+ * @param <T> type of the UIComponent
  * @author <a href="mailto:patrice.lamarque@exoplatform.com">Patrice Lamarque</a>
  * @version $Revision$
  */


### PR DESCRIPTION
add maven-surefire-plugin necessary configuration arglines to use JDK 17 and fix javadocs tags
