### PR TITLE
fix: Fix email notifications aren't received when external username contains "@"

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
@@ -121,10 +121,7 @@ public class NotificationPluginUtils {
   }
   
   public static String getTo(String to) {
-    if (to.indexOf("@") < 0) {
-      return getEmailFormat(to);
-    }
-    return to;
+    return getEmailFormat(to);
   }
 
   /**


### PR DESCRIPTION
Prior to this change, when inviting an external user in a space and after creating the external profile with a first name or a last name including "@", the email notifications of this external user aren't received. The problem is that in the case of a username including the "@", the email notifications are sent to the username (not a valid email) and not to the right user email. After this change, we ensure to always send the email notifications to the user email regardless the format of the username.

(cherry picked from commit 66185105c530f8b1c24208c9fffb58f738db4799)