### PR TITLE
fix: Add missing JAR dependency to add in Meeds Package - Meeds-io/meeds#479

### DIFF
--- a/commons-component-common/pom.xml
+++ b/commons-component-common/pom.xml
@@ -119,7 +119,6 @@
     <dependency>
       <groupId>org.imgscalr</groupId>
       <artifactId>imgscalr-lib</artifactId>
-      <scope>provided</scope>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
Prior to this change, the user avatars weren't displayed due to a missing JAR in Meeds Package (Error Message : NoClassDefFoundError: org/imgscalr/Scalr). This change will make the dependency to imgscalr-lib transitive so that it's imported in Meeds package.