### PR TITLE
fix: Agenda - No notification is sent when inviting guest users to an event - EXO-61764 (#444)

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/NotificationConstants.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/NotificationConstants.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2003-2023 eXo Platform SAS.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Affero General Public License
+ * as published by the Free Software Foundation; either version 3
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see<http://www.gnu.org/licenses/>.
+ */
+
+package org.exoplatform.commons.api.notification;
+
+import java.util.regex.Pattern;
+
+public class NotificationConstants {
+
+  public static final String  BRANDING_PORTAL_NAME              = "exo:brandingPortalName";
+
+  public static final String  BRANDING_COMPANY_NAME_SETTING_KEY = "exo.branding.company.name";
+
+  public static final Pattern EMAIL_PATTERN                     =
+                                            Pattern.compile("^[_a-zA-Z0-9-+]+(\\.[_a-zA-Z0-9-]+)*@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*(\\.[a-zA-Z]{2,})$");
+
+  public static final String  EXO_IS_ACTIVE                     = "exo:isActive";
+
+  public static final String  DEFAULT_SUBJECT_KEY               = "Notification.subject.{0}";
+
+  public static final String  DEFAULT_SIMPLE_DIGEST_KEY         = "Notification.digest.{0}";
+
+  public static final String  DEFAULT_DIGEST_ONE_KEY            = "Notification.digest.one.{0}";
+
+  public static final String  DEFAULT_DIGEST_THREE_KEY          = "Notification.digest.three.{0}";
+
+  public static final String  DEFAULT_DIGEST_MORE_KEY           = "Notification.digest.more.{0}";
+
+  public static final String  FEATURE_NAME                      = "notification";
+
+  public static final Pattern LINK_PATTERN                      = Pattern.compile("<a ([^>]+)>([^<]+)</a>");
+
+  public static final Pattern NOTIFICATION_SENDER_NAME_PATTERN  = Pattern.compile("^[a-zA-Z]+[a-zA-Z ]*$");
+
+  public static final String  styleCSS                          = " style=\"color: #2f5e92; text-decoration: none;\"";
+
+  /**
+   * This value must be the same with
+   * CalendarSpaceActivityPublisher.CALENDAR_APP_ID
+   */
+  public static final String  CALENDAR_ACTIVITY                 = "cs-calendar:spaces";
+}

--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
@@ -17,6 +17,7 @@
 package org.exoplatform.commons.api.notification.plugin;
 
 import java.util.Locale;
+import java.util.regex.Matcher;
 
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.api.settings.SettingService;
@@ -35,11 +36,9 @@ import org.exoplatform.portal.localization.LocaleContextInfoUtils;
 import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.LocalePolicy;
 
-public class NotificationPluginUtils {
+import static org.exoplatform.commons.api.notification.NotificationConstants.*;
 
-  public static final String BRANDING_PORTAL_NAME = "exo:brandingPortalName";
-  
-  public static final String BRANDING_COMPANY_NAME_SETTING_KEY = "exo.branding.company.name";
+public class NotificationPluginUtils {
 
   public static String getPortalName() {
     return getExoContainerContext().getPortalContainerName();
@@ -121,9 +120,13 @@ public class NotificationPluginUtils {
   }
   
   public static String getTo(String to) {
-    return getEmailFormat(to);
+    return isValidEmail(to) ? to : getEmailFormat(to);
   }
 
+  public static boolean isValidEmail(String to) {
+    Matcher matcher = EMAIL_PATTERN.matcher(to.trim());
+    return matcher.find() ;
+  }
   /**
    * @param userId
    * @return

--- a/commons-api/src/test/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtilsTest.java
+++ b/commons-api/src/test/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtilsTest.java
@@ -1,7 +1,5 @@
 package org.exoplatform.commons.api.notification.plugin;
 
-import static org.exoplatform.commons.api.notification.plugin.NotificationPluginUtils.BRANDING_COMPANY_NAME_SETTING_KEY;
-
 import org.mockito.Mockito;
 
 import org.exoplatform.commons.api.settings.SettingService;
@@ -11,6 +9,8 @@ import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.component.test.*;
 import org.exoplatform.services.organization.*;
 import org.exoplatform.services.organization.impl.UserProfileImpl;
+
+import static org.exoplatform.commons.api.notification.NotificationConstants.BRANDING_COMPANY_NAME_SETTING_KEY;
 
 /**
  * Created by eXo Platform SAS.

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/NotificationUtils.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/NotificationUtils.java
@@ -19,7 +19,6 @@ package org.exoplatform.commons.notification;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
@@ -38,33 +37,11 @@ import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.organization.OrganizationService;
 
+import static org.exoplatform.commons.api.notification.NotificationConstants.*;
+
 
 public class NotificationUtils {
 
-  public static final String EXO_IS_ACTIVE             = "exo:isActive";
-
-  public static final String DEFAULT_SUBJECT_KEY       = "Notification.subject.{0}";
-
-  public static final String DEFAULT_SIMPLE_DIGEST_KEY = "Notification.digest.{0}";
-
-  public static final String DEFAULT_DIGEST_ONE_KEY    = "Notification.digest.one.{0}";
-
-  public static final String DEFAULT_DIGEST_THREE_KEY  = "Notification.digest.three.{0}";
-  
-  public static final String DEFAULT_DIGEST_MORE_KEY   = "Notification.digest.more.{0}";
-
-  public static final String FEATURE_NAME              = "notification";
-  
-  private static final Pattern LINK_PATTERN = Pattern.compile("<a ([^>]+)>([^<]+)</a>");
-
-  private static final Pattern EMAIL_PATTERN = Pattern.compile("^[_a-zA-Z0-9-+]+(\\.[_a-zA-Z0-9-]+)*@[a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)*(\\.[a-zA-Z]{2,})$");
-
-  private static final Pattern NOTIFICATION_SENDER_NAME_PATTERN = Pattern.compile("^[a-zA-Z]+[a-zA-Z ]*$");
-  
-  private static final String styleCSS = " style=\"color: #2f5e92; text-decoration: none;\"";
-  
-  /** This value must be the same with CalendarSpaceActivityPublisher.CALENDAR_APP_ID */
-  public static final String CALENDAR_ACTIVITY = "cs-calendar:spaces";
   
   public static String getDefaultKey(String key, String providerId) {
     return MessageFormat.format(key, providerId);

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/command/NotificationExecutorImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/command/NotificationExecutorImpl.java
@@ -26,13 +26,14 @@ import org.exoplatform.commons.api.notification.command.NotificationExecutor;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.service.NotificationCompletionService;
 import org.exoplatform.commons.api.notification.service.storage.NotificationService;
-import org.exoplatform.commons.notification.NotificationUtils;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+
+import static org.exoplatform.commons.api.notification.NotificationConstants.FEATURE_NAME;
 
 public class NotificationExecutorImpl implements NotificationExecutor {
 
@@ -93,7 +94,7 @@ public class NotificationExecutorImpl implements NotificationExecutor {
     boolean result = true;
 
     // Notification will not be executed when the feature is off
-    if (CommonsUtils.isFeatureActive(NotificationUtils.FEATURE_NAME) == false) {
+    if (CommonsUtils.isFeatureActive(FEATURE_NAME) == false) {
       commands.clear();
       return result;
     }

--- a/commons-component-common/src/test/java/org/exoplatform/commons/utils/NotificationUtilsTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/utils/NotificationUtilsTest.java
@@ -19,6 +19,8 @@ package org.exoplatform.commons.utils;
 import org.exoplatform.commons.notification.NotificationUtils;
 import org.exoplatform.commons.testing.BaseCommonsTestCase;
 
+import static org.exoplatform.commons.api.notification.NotificationConstants.CALENDAR_ACTIVITY;
+
 /**
  * Created by The eXo Platform SAS
  * Author : eXoPlatform
@@ -33,7 +35,7 @@ public class NotificationUtilsTest extends BaseCommonsTestCase {
     assertEquals(newTitle, NotificationUtils.removeLinkTitle(title));
     
     title = "MHM&amp;#39s B-day Party";
-    assertEquals("MHM&#39s B-day Party", NotificationUtils.getNotificationActivityTitle(title, NotificationUtils.CALENDAR_ACTIVITY));
+    assertEquals("MHM&#39s B-day Party", NotificationUtils.getNotificationActivityTitle(title, CALENDAR_ACTIVITY));
     
     title = "MHM&amp;#39s B-day Party";
     assertEquals("MHM&amp;#39s B-day Party", NotificationUtils.getNotificationActivityTitle(title, ""));

--- a/commons-extension-webapp/src/main/java/org/exoplatform/platform/portlet/juzu/notificationsAdmin/NotificationsAdministration.java
+++ b/commons-extension-webapp/src/main/java/org/exoplatform/platform/portlet/juzu/notificationsAdmin/NotificationsAdministration.java
@@ -49,6 +49,8 @@ import juzu.request.ApplicationContext;
 import juzu.request.UserContext;
 import juzu.template.Template;
 
+import static org.exoplatform.commons.api.notification.NotificationConstants.FEATURE_NAME;
+
 public class NotificationsAdministration {
   private static final Log LOG    = ExoLogger.getLogger(NotificationsAdministration.class);
 
@@ -73,7 +75,7 @@ public class NotificationsAdministration {
   @View
   public Response index(ApplicationContext applicationContext, UserContext userContext) {
     // Redirect yo the home's page when the feature is off
-    if (!CommonsUtils.isFeatureActive(NotificationUtils.FEATURE_NAME)) {
+    if (!CommonsUtils.isFeatureActive(FEATURE_NAME)) {
       return redirectToHomePage();
     }
 


### PR DESCRIPTION
prior to this change, when inviting a guest user to an event, its email is set to the notifications receivers, when trying to get a user with its email no user is found since it is a guest. After this change, when getting the "To" email it is tested if it is a valid email or not, if it is the case it returns the email of the guest user
