### PR TITLE
fix: ckeditor comments content - EXO-60626

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/skins/moono-exo/less/editor.less
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/skins/moono-exo/less/editor.less
@@ -144,7 +144,6 @@
 .cke_contents {
   display:block;
   overflow:hidden;
-  margin-top: -2px;
   .border-bottom-radius(5px);
 }
 .cke_bottom, .cke_top {


### PR DESCRIPTION
prior to this change, comment CKeditor is not well displayed The top border of the comment is no more visible.
after this change,  comment CKeditor is well displayed