### PR TITLE
fix: Add the missing technical label for the description of the unread activities channel - Meeds-io/meeds#790 - EXO-63042

### DIFF
--- a/commons-extension-webapp/src/main/resources/locale/portlet/notification/UserNotificationPortlet_en.properties
+++ b/commons-extension-webapp/src/main/resources/locale/portlet/notification/UserNotificationPortlet_en.properties
@@ -8,6 +8,7 @@ UINotification.label.channel-mail=Notify me by email
 UINotification.description.channel-mail=You will be notified by an email sent to your private mail box
 UINotification.label.channel-web=Notify me on-site
 UINotification.label.channel-space_web=Notify me when unread activities
+UINotification.description.channel-space_web=You will be notified in the left menu and in the stream.
 UINotification.description.channel-web=You'll receive a notification directly on the website.
 UINotification.label.channel.default=Notify me by {0}
 UINotification.description.channel.default=You will be notified by {0}

--- a/commons-extension-webapp/src/main/resources/locale/portlet/notification/UserNotificationPortlet_fr.properties
+++ b/commons-extension-webapp/src/main/resources/locale/portlet/notification/UserNotificationPortlet_fr.properties
@@ -8,6 +8,7 @@ UINotification.label.channel-mail=E-mail
 UINotification.description.channel-mail=Vous recevrez une notification par email
 UINotification.label.channel-web=Site
 UINotification.label.channel-space_web=Me notifier en cas d'activit\u00E9 non lue
+UINotification.description.channel-space_web=Vous serez notifi\u00E9 depuis le menu de gauche and dans le fil d'activit\u00E9s.
 UINotification.description.channel-web=Vous recevrez une notification directement sur le site
 UINotification.label.channel.default=Me notifier par {0}
 UINotification.description.channel.default=Vous serez notifi\u00E9 par {0}


### PR DESCRIPTION


This change is going to add the missing technical label for the description of the unread activities channel.

