### PR TITLE
fix: Fix CKEditor dialog style - MEED-1955 - Meeds-io/MIPs#52

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/dialog/styles/dialog.css
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/dialog/styles/dialog.css
@@ -18,6 +18,9 @@
 .simpleLinkDialog > .cke_dialog {
 	position: relative !important;
 }
+.cke_dialog {
+  width: auto;
+}
 input#cke_61_textInput {
 	width: 100%;
 }
@@ -29,6 +32,11 @@ textarea#cke_58_textarea {
 	height: 40px;
 	resize: none;
 	padding: 9px 0;
+}
+.uiActionBorder {
+  border-top: none;
+  text-align: center;
+  padding: 15px 0;
 }
 @media (min-width: 768px) and (max-width: 1024px) {
 	.btn.btn-primary, .btn-primary {


### PR DESCRIPTION
Prior to this change, the dialogs in CKEditor was displayed in full width of the page and the actions not centered. This change will introduce CSS for CKEditor which was deprecated on platform-ui.