### PR TITLE
fix: Fix blank notification settings and administration pages after upgrade from 6.3.x to 6.4.x - EXO-62945 -  Meeds-io/meeds#850

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/NotificationUtils.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/NotificationUtils.java
@@ -134,13 +134,12 @@ public class NotificationUtils {
   }
 
   public static List<String> stringToList(String value) {
-    if (StringUtils.isBlank(value)) {
-      return Collections.emptyList();
-    }
-    List<String> result = new ArrayList<>();
-    StringTokenizer tokenizer = new StringTokenizer(value, ",");
-    while (tokenizer.hasMoreTokens()) {
-      result.add(tokenizer.nextToken());
+    List<String> result = new ArrayList<>();    
+    if (!StringUtils.isBlank(value)) {
+      StringTokenizer tokenizer = new StringTokenizer(value, ",");
+      while (tokenizer.hasMoreTokens()) {
+        result.add(tokenizer.nextToken());
+      }
     }
     return result;
   }

--- a/commons-component-common/src/test/java/org/exoplatform/commons/utils/NotificationUtilsTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/utils/NotificationUtilsTest.java
@@ -16,10 +16,12 @@
  */
 package org.exoplatform.commons.utils;
 
+import static org.exoplatform.commons.api.notification.NotificationConstants.CALENDAR_ACTIVITY;
+
+import java.util.List;
+
 import org.exoplatform.commons.notification.NotificationUtils;
 import org.exoplatform.commons.testing.BaseCommonsTestCase;
-
-import static org.exoplatform.commons.api.notification.NotificationConstants.CALENDAR_ACTIVITY;
 
 /**
  * Created by The eXo Platform SAS
@@ -29,6 +31,15 @@ import static org.exoplatform.commons.api.notification.NotificationConstants.CAL
  */
 public class NotificationUtilsTest extends BaseCommonsTestCase {
 
+  public void testAddToListFromEmptyString() {
+    try {
+      List<String> emptyStringList = NotificationUtils.stringToList("");
+      assertTrue(emptyStringList.add("test"));
+    } catch (UnsupportedOperationException unsupportedOperationException) {
+      fail("Fail to add an item to the list due to UnsupportedOperationException of add operation");
+    }
+  }
+  
   public void testRemoveLinkTitle() {
     String title = "<a href=\"http://exoplatform.github.io/\" target=\"_blank\">http://exoplatform.github.io/</a>";
     String newTitle = "<span class=\"user-name text-bold\">http://exoplatform.github.io/</span>";


### PR DESCRIPTION
Prior to this fix, when we upgrade from 6.3.x with at least a notification plugin having empty channels to 6.4.x, the notification administration and notification settings pages are no more displayed with UnsupportedOperationException. In fact, on 6.4.x a new channel "Unread Notifications" is implemented which can not be added to 6.3.x data since the method addAll() can not be executed on the final result of Collections.emptyList(). After this commit, if no channel is detected we will use new ArrayList<>() instead of Collections.emptyList() in order to make addAll() method execution possible.