### PR TITLE
fix: Fix Toogle CKEditor Format when multiple CKeditors - MEED-2109 - Meeds-io/MIPs#49

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/formatOption/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/formatOption/plugin.js
@@ -7,9 +7,9 @@ CKEDITOR.plugins.add( 'formatOption', {
   init: function( editor ) {
     editor.addCommand('formatOption', {
       exec: function() {
-        const toolbarWrapper = document.getElementsByClassName("cke_toolgroup");
-        toolbarWrapper[0].classList.toggle("fullToolbar");
-        if (toolbarWrapper[0].classList.contains('fullToolbar')) {
+        const toolbarWrapper = document.querySelector(`.${editor.id} .cke_toolgroup`);
+        toolbarWrapper.classList.toggle("fullToolbar");
+        if (toolbarWrapper.classList.contains('fullToolbar')) {
           document.dispatchEvent(new CustomEvent('editors-options-opened', {detail: 'displayFormatOptions'} ));
         } else {
           document.dispatchEvent(new CustomEvent('editors-options-opened', {detail: 'displayRichOptions'} ));


### PR DESCRIPTION
Prior to this change, when having two CKEditor in the same page, the Format Button toggles only one instance's toolbar. This change will search for current instance CKEDitor identified by its id.