### PR TITLE
feat: Use Branding Name in Mail Subject instead of Property - MEED-2258 - Meeds-io/meeds#992

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
@@ -19,11 +19,6 @@ package org.exoplatform.commons.api.notification.plugin;
 import java.util.Locale;
 import java.util.regex.Matcher;
 
-import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.commons.api.settings.SettingService;
-import org.exoplatform.commons.api.settings.SettingValue;
-import org.exoplatform.commons.api.settings.data.Context;
-import org.exoplatform.commons.api.settings.data.Scope;
 import org.exoplatform.commons.utils.MailUtils;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
@@ -32,6 +27,7 @@ import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.organization.User;
 import org.exoplatform.services.organization.UserHandler;
+import org.exoplatform.portal.branding.BrandingService;
 import org.exoplatform.portal.localization.LocaleContextInfoUtils;
 import org.exoplatform.services.resources.LocaleContextInfo;
 import org.exoplatform.services.resources.LocalePolicy;
@@ -112,11 +108,7 @@ public class NotificationPluginUtils {
    * @return
    */
   public static String getBrandingPortalName() {
-    SettingValue<?> name = getSettingService().get(Context.GLOBAL, Scope.GLOBAL.id(null), BRANDING_PORTAL_NAME);
-    if (name == null) {
-      name = getSettingService().get(Context.GLOBAL, Scope.GLOBAL, BRANDING_COMPANY_NAME_SETTING_KEY);
-    }
-    return name != null && StringUtils.isNotBlank((CharSequence) name.getValue()) ? (String) name.getValue() : "eXo";
+    return getBrandingService().getCompanyName();
   }
   
   public static String getTo(String to) {
@@ -146,8 +138,8 @@ public class NotificationPluginUtils {
       return ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(OrganizationService.class);
   }
   
-  public static SettingService getSettingService() {
-    return ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(SettingService.class);
+  public static BrandingService getBrandingService() {
+    return ExoContainerContext.getCurrentContainer().getComponentInstanceOfType(BrandingService.class);
   }
 
   private static void startRequest(Object service) {

--- a/commons-api/src/test/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtilsTest.java
+++ b/commons-api/src/test/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtilsTest.java
@@ -1,30 +1,27 @@
 package org.exoplatform.commons.api.notification.plugin;
 
-import org.mockito.Mockito;
-
-import org.exoplatform.commons.api.settings.SettingService;
-import org.exoplatform.commons.api.settings.SettingValue;
-import org.exoplatform.commons.api.settings.data.Context;
-import org.exoplatform.commons.api.settings.data.Scope;
-import org.exoplatform.component.test.*;
-import org.exoplatform.services.organization.*;
+import org.exoplatform.component.test.AbstractKernelTest;
+import org.exoplatform.component.test.ConfigurationUnit;
+import org.exoplatform.component.test.ConfiguredBy;
+import org.exoplatform.component.test.ContainerScope;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.branding.BrandingService;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.services.organization.UserProfile;
+import org.exoplatform.services.organization.UserProfileHandler;
 import org.exoplatform.services.organization.impl.UserProfileImpl;
-
-import static org.exoplatform.commons.api.notification.NotificationConstants.BRANDING_COMPANY_NAME_SETTING_KEY;
 
 /**
  * Created by eXo Platform SAS.
  *
  * @author Ali Hamdi <ahamdi@exoplatform.com>
- * @since 15/02/18 10:23
+ * @since  15/02/18 10:23
  */
 
-@ConfiguredBy(
-  {
-      @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
-      @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
-  }
-)
+@ConfiguredBy({
+    @ConfigurationUnit(scope = ContainerScope.ROOT, path = "conf/configuration.xml"),
+    @ConfigurationUnit(scope = ContainerScope.PORTAL, path = "conf/portal/configuration.xml"),
+})
 public class NotificationPluginUtilsTest extends AbstractKernelTest {
 
   public void testGetLanguage() throws Exception {
@@ -58,16 +55,7 @@ public class NotificationPluginUtilsTest extends AbstractKernelTest {
   }
 
   public void testGetBrandingPortalName() throws Exception {
-    SettingService settingService = Mockito.mock(SettingService.class);
-    getContainer().unregisterComponent(SettingService.class);
-    getContainer().registerComponentInstance(SettingService.class, settingService);
-
-    String companyName = "ACME";
-    SettingValue value = new SettingValue(companyName);
-    Mockito.when(settingService.get(Context.GLOBAL, Scope.GLOBAL, BRANDING_COMPANY_NAME_SETTING_KEY)).thenReturn(value);
-
-    // Make sure that method getBrandingPortalName returns the changed company
-    // name.
-    assertEquals(companyName, NotificationPluginUtils.getBrandingPortalName());
+    assertEquals(ExoContainerContext.getService(BrandingService.class).getCompanyName(),
+                 NotificationPluginUtils.getBrandingPortalName());
   }
 }


### PR DESCRIPTION
Prior to this change, the property name 'exo.notifications.portalname' with default value when not set 'eXo' was used in Email subjects. This change will allow to use Branding Name instead.