### PR TITLE
fix: Fix displaying notification when built message is null - MEED-1650 - Meeds-io/meeds#576

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/lifecycle/WebLifecycle.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/lifecycle/WebLifecycle.java
@@ -60,6 +60,9 @@ public class WebLifecycle extends AbstractNotificationLifecycle {
       store(ctx.getNotificationInfo());
       //build message
       MessageInfo msg = buildMessageInfo(ctx);
+      if (msg == null) {
+        continue;
+      }
 
       String notificationId = ctx.getNotificationInfo().getId();
       ctx.append(WebChannel.MESSAGE_INFO, msg);


### PR DESCRIPTION
Prior to this change, when the built notification message is null, the Notification processing continues while it should be interrupted. This change will make sure to interrupt tentative of Null Notification Message processing.