### PR TITLE
fix: add Natural sorting comparator for Strings with digits - EXO-46735 - Meeds-io/meeds#1056

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/comparators/NaturalComparator.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/comparators/NaturalComparator.java
@@ -1,0 +1,39 @@
+package org.exoplatform.commons.comparators;
+
+import java.util.Comparator;
+
+public class NaturalComparator implements Comparator<String> {
+  @Override
+  public int compare(String s1, String s2) {
+      /*
+      Split string by matching a position where a non-digit (\\D) precedes and a digit (\\d) follows or vice versa
+      (?<=) matches the position immediately following a non-digit (\\D) or a digit (\\d) character
+      (?=) matches the position immediately preceding a non-digit (\\D) or a digit (\\d) character
+       */
+    if(s1 == null) {
+      return 1;
+    }
+    if(s2 == null) {
+      return -1;
+    }
+    String[] arr1 = s1.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
+    String[] arr2 = s2.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
+    int i = 0;
+    while (i < arr1.length && i < arr2.length) {
+      if (Character.isDigit(arr1[i].charAt(0)) && Character.isDigit(arr2[i].charAt(0))) {
+        int num1 = Integer.parseInt(arr1[i]);
+        int num2 = Integer.parseInt(arr2[i]);
+        if (num1 != num2) {
+          return Integer.compare(num1, num2);
+        }
+      } else {
+        int result = arr1[i].compareToIgnoreCase(arr2[i]);
+        if (result != 0) {
+          return result;
+        }
+      }
+      i++;
+    }
+    return s1.compareToIgnoreCase(s2);
+  }
+}

--- a/commons-component-common/src/test/java/org/exoplatform/commons/comparators/NaturalComparatorTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/comparators/NaturalComparatorTest.java
@@ -1,0 +1,45 @@
+package org.exoplatform.commons.comparators;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class NaturalComparatorTest extends TestCase {
+
+  @Test
+  public void testNaturalCompare(){
+    List<String> list = new ArrayList<>();
+    list.add("1");
+    list.add("3");
+    list.add("2");
+
+    list.sort(new NaturalComparator());
+    //assert numeric sort
+    assertEquals("1", list.get(0));
+    assertEquals("3", list.get(2));
+
+    list.add("Afile");
+    list.add("bfile");
+    list.sort(new NaturalComparator());
+    //assert numeric sort then literal sort
+    assertEquals("1", list.get(0));
+    assertEquals("Afile", list.get(3));
+
+    list.add("file1");
+    list.add("file10");
+    list.add("file2");
+    list.add("file20");
+    list.add("file3");
+    list.add("2 test");
+
+    list.sort(new NaturalComparator());
+    String[] expectedSortedArray = new String[]{"1", "2", "2 test", "3", "Afile", "bfile", "file1", "file2", "file3" ,"file10", "file20"};
+    for(int i = 0; i < list.size(); i++) {
+      assertEquals(expectedSortedArray[i], list.get(i));
+    }
+
+  }
+
+}


### PR DESCRIPTION
When sorting Strings, it uses by default ASCII codes which makes "test 10" comes before "test 2"
The added comparator ensures ordering Strings with incremented digits : "test 1" "test 2" "test 10" "test 21", etc ... 