### PR TITLE
fix: Upgrade Plugin are not comparing meeds version correctly - meeds-io/meeds#1072

### DIFF
--- a/commons-component-upgrade/src/main/java/org/exoplatform/commons/version/util/ComparableVersion.java
+++ b/commons-component-upgrade/src/main/java/org/exoplatform/commons/version/util/ComparableVersion.java
@@ -68,6 +68,7 @@ public class ComparableVersion
     implements Comparable<ComparableVersion>
 {
     private static final Pattern CICD_VERSION_PATTERN = Pattern.compile("(.*)-([0-9]{8})$");
+    private static final String[] MEMBERS = { "exo", "meed" };
 
     private String value;
 
@@ -160,7 +161,6 @@ public class ComparableVersion
         private static final Log LOG = ExoLogger.getLogger(StringItem.class);
         
         private static final String[] QUALIFIERS = { "snapshot", "alpha", "beta", "cicd", "milestone", "rev", "rc", "", "sp" };
-
         private static final List<String> _QUALIFIERS = Arrays.asList( QUALIFIERS );
 
         private static final Properties ALIASES = new Properties();
@@ -363,6 +363,11 @@ public class ComparableVersion
 
     public final void parseVersion( String version )
     {
+
+        for (String s : MEMBERS) {
+            version = version.replace("-"+s+"-","-");
+        }
+
         Matcher matcher = CICD_VERSION_PATTERN.matcher(version.trim());
         if (matcher.find()) {
           this.value = version = matcher.replaceFirst("$1-cicd$2");

--- a/commons-component-upgrade/src/test/java/org/exoplatform/commons/version/util/ComparableVersionTest.java
+++ b/commons-component-upgrade/src/test/java/org/exoplatform/commons/version/util/ComparableVersionTest.java
@@ -113,6 +113,9 @@ public class ComparableVersionTest
         checkVersionsEqual( "1a1", "1alpha1" );
         checkVersionsEqual( "1b2", "1beta2" );
         checkVersionsEqual( "1m3", "1milestone3" );
+        checkVersionsEqual( "1.5.0-meed-20230818", "1.5.0-meed-20230818" );
+        checkVersionsEqual( "6.5.0-exo-20230818", "6.5.0-exo-20230818" );
+
     }
 
     public void testVersionComparing()
@@ -144,6 +147,13 @@ public class ComparableVersionTest
 
         checkVersionsOrder( "2.0.1", "2.0.1-123" );
         checkVersionsOrder( "2.0.1-xyz", "2.0.1-123" );
+
+
+        checkVersionsOrder( "1.5.0-meed-20230818","1.5.0" );
+        checkVersionsOrder( "1.5.0-meed-20230817", "1.5.0-meed-20230818" );
+
+        checkVersionsOrder( "6.5.0-exo-20230818", "6.5.0" );
+        checkVersionsOrder( "6.5.0-exo-20230817", "6.5.0-exo-20230818" );
     }
 
     public void testLocaleIndependent()


### PR DESCRIPTION
Before this fix, the version comparison is not working for cicd version of meeds. For example the comparison says 1.5.0-meed-20230815 > 1.5.0-meed-20230816 
This commit remove the '-meed' string in order to compare correctly 1.5.0-20230815 with 1.5.0-20230816, which correctly return 1.5.0-20230815 < 1.5.0-20230816

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
