### PR TITLE
fix: No key for Documents label in settings>Manage notifications page - EXO-64493 - Meeds-io/meeds#1074.

### DIFF
--- a/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_en.properties
+++ b/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_en.properties
@@ -3,6 +3,7 @@ UINotification.label.group.Connections=Connections
 UINotification.label.group.Spaces=Spaces
 UINotification.label.group.ActivityStream=Activity Stream
 UINotification.label.group.Documents=Document Sharing
+UINotification.label.group.documents=Documents
 UINotification.label.group.Other=Other
 
 #############################################################################


### PR DESCRIPTION
Prior to this change, when my platform is configured to any language except English, go to my settings>Manage notifications page then check the Documents label, the label: documents isn't translated to the selected plf language.To fix this problem, added a key to documents label so it could be translated via Crowdin.