### PR TITLE
fix: No key for Documents label in settings>Manage notifications page - EXO-64493 - Meeds-io/meeds#1074

### DIFF
--- a/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_de.properties
+++ b/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_de.properties
@@ -3,6 +3,7 @@ UINotification.label.group.Connections=Verbindungen
 UINotification.label.group.Spaces=R\u00E4ume
 UINotification.label.group.ActivityStream=Aktivit\u00E4ten
 UINotification.label.group.Documents=Dokumente wurden freigegeben
+UINotification.label.group.documents=Dokumente
 UINotification.label.group.Other=Andere
 
 #############################################################################

--- a/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_en.properties
+++ b/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_en.properties
@@ -3,6 +3,7 @@ UINotification.label.group.Connections=Connections
 UINotification.label.group.Spaces=Spaces
 UINotification.label.group.ActivityStream=Activity Stream
 UINotification.label.group.Documents=Document Sharing
+UINotification.label.group.documents=Documents
 UINotification.label.group.Other=Other
 
 #############################################################################

--- a/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_fr.properties
+++ b/commons-extension-webapp/src/main/resources/locale/notification/template/CommonsNotification_fr.properties
@@ -3,6 +3,7 @@ UINotification.label.group.Connections=R\u00E9seau
 UINotification.label.group.Spaces=Espaces
 UINotification.label.group.ActivityStream=Fil d'activit\u00E9s
 UINotification.label.group.Documents=Documents Partag\u00E9s
+UINotification.label.group.documents=Documents
 UINotification.label.group.Other=Autre
 
 #############################################################################


### PR DESCRIPTION
Prior to this change, when my platform is configured to any language except English, go to my settings>Manage notifications page then check the Documents label, the label: documents isn't translated to the selected plf language.To fix this problem, added a key to documents label so it could be translated via Crowdin.

(cherry picked from commit https://github.com/Meeds-io/commons/commit/374e92efee7f766c10726364aa51be91ba88a7a9)