### PR TITLE
fix :Error when getting notes app tree drafts after creating a new draft page without title - EXO-65932 - Meeds-io/meeds#1077

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/comparators/NaturalComparator.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/comparators/NaturalComparator.java
@@ -1,5 +1,7 @@
 package org.exoplatform.commons.comparators;
 
+import org.apache.commons.lang.StringUtils;
+
 import java.util.Comparator;
 
 public class NaturalComparator implements Comparator<String> {
@@ -20,7 +22,7 @@ public class NaturalComparator implements Comparator<String> {
     String[] arr2 = s2.split("(?<=\\D)(?=\\d)|(?<=\\d)(?=\\D)");
     int i = 0;
     while (i < arr1.length && i < arr2.length) {
-      if (Character.isDigit(arr1[i].charAt(0)) && Character.isDigit(arr2[i].charAt(0))) {
+      if (StringUtils.isNotBlank(arr1[i]) && Character.isDigit(arr1[i].charAt(0)) && StringUtils.isNotBlank(arr2[i]) && Character.isDigit(arr2[i].charAt(0))) {
         int num1 = Integer.parseInt(arr1[i]);
         int num2 = Integer.parseInt(arr2[i]);
         if (num1 != num2) {


### PR DESCRIPTION
Before to this change, an error would occur when we trying to retrieve the draft of a notes app tree. This happened after creating a new draft page without a title. The issue was caused by the checked if a character was a digit using the natural compactor. With this change , we firstly check if the character isn't blank before verifying if it's a digit.