### PR TITLE
fix: Fix Suggester doesn't appear anymore on CKEditor - EXO-66237 - Meeds-io/meeds#1079 

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/editorplaceholder/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/editorplaceholder/plugin.js
@@ -85,11 +85,13 @@
 			editable = editor.editable(),
 			placeholder = editor.config.editorplaceholder;
 
-		if ( !isEditorEmpty( editor )) {
-			return editable.removeAttribute( ATTRIBUTE_NAME );
-		}
-
-		editable.setAttribute( ATTRIBUTE_NAME, placeholder );
+    window.setTimeout(() => {
+      if (isEditorEmpty(editor)) {
+        editable.setAttribute(ATTRIBUTE_NAME, placeholder);
+      } else {
+        editable.removeAttribute(ATTRIBUTE_NAME);
+      }
+    }, 50);
 	}
 
 	/**


### PR DESCRIPTION
Prior to this change, after adding the 'editorplaceholder' plugin into CKEditor, the 'getData' method on editor is blocked by suggester which overrides it. This change will make sure to not update the placeholder in sync way when the event 'change' is triggered.
