### PR TITLE
fix: Fix Unread Flag Count Update after Marking as Unread a Web Notification - MEED-2551 - Meeds-io/meeds#1111

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/storage/cache/CachedWebNotificationStorage.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/storage/cache/CachedWebNotificationStorage.java
@@ -101,8 +101,7 @@ public class CachedWebNotificationStorage implements WebNotificationStorage {
   @Override
   public void markRead(String notificationId) {
     storage.markRead(notificationId);
-    //
-    updateRead(notificationId, true);
+    updateRead(notificationId);
   }
 
   @Override
@@ -237,12 +236,11 @@ public class CachedWebNotificationStorage implements WebNotificationStorage {
     updateCacheByUser(userId);
   }
 
-  private void updateRead(String notificationId, boolean isRead) {
+  private void updateRead(String notificationId) {
     WebNotifInfoCacheKey key = WebNotifInfoCacheKey.key(notificationId);
     WebNotifInfoData infoData = webNotificationCache.get(key);
     if (infoData != null) {
-      infoData.updateRead(isRead);
-      webNotificationCache.put(key, infoData);
+      updateCacheByUser(infoData.getTo());
     }
   }
 

--- a/commons-component-common/src/test/java/org/exoplatform/commons/notification/storage/CachedWebNotificationStorageTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/commons/notification/storage/CachedWebNotificationStorageTest.java
@@ -133,7 +133,9 @@ public class CachedWebNotificationStorageTest extends BaseNotificationTestCase {
     NotificationInfo notifInfo = cachedStorage.get(info.getId());
     assertFalse(notifInfo.isRead());
     //
+    assertEquals(1, cachedStorage.countUnreadByPlugin(userId).size());
     cachedStorage.markRead(notifInfo.getId());
+    assertEquals(0, cachedStorage.countUnreadByPlugin(userId).size());
     //
     notifInfo = cachedStorage.get(info.getId());
     assertTrue(notifInfo.isRead());


### PR DESCRIPTION
Prior to this change, the 'read' flag on web notifications were updated in database after reading the notification by the user. Whereas, the List and Count caches wasn't updated consequently. This change will ensure to purge data for user's web notifications in order to refresh count.