### PR TITLE
feat: Allow caption and summary on table element in HTML sanitizer - EXO-65716 - Meeds-io/MIPs#71

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
@@ -184,6 +184,8 @@ abstract public class HTMLSanitizer {
                                                                                                                                 .allowAttributes("noresize")
                                                                                                                                 .matching(Pattern.compile("(?i)noresize"))
                                                                                                                                 .onElements("table")
+                                                                                                                                .allowAttributes("summary")
+                                                                                                                                .onElements("table")
                                                                                                                                 .allowAttributes("background")
                                                                                                                                 .matching(ONSITE_URL)
                                                                                                                                 .onElements("td",
@@ -346,6 +348,7 @@ abstract public class HTMLSanitizer {
                                                                                                                                 .globally()
                                                                                                                                 .allowAttributes("v-identity-popover")
                                                                                                                                 .globally()
+                                                                                                                                .allowElements("caption")
                                                                                                                                 .toFactory();
 
   /**


### PR DESCRIPTION
Allow caption and summary on table element in HTML sanitizer

