### PR TITLE
feat: Icons of cke context menu are not correctly shown - EXO-65722 -Meeds-io/MIPs#71

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/skins/moono-exo/less/editor.less
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/skins/moono-exo/less/editor.less
@@ -743,6 +743,7 @@ a.cke_button {
   //height:@height9;
   margin-top:1px;
   width:16px;
+  height: 16px;
   line-height: 17px;
 }
 .cke_button_label {


### PR DESCRIPTION
Prior to this change, defnied styles icons of cke context menu are not shown due to the fact that the size of icons is not well set. This PR updates the size of the icons in order to correctly display it
