### PR TITLE
fix: Task notification like mention are not displayed in site in certain case - EXO-66779 - meeds-io/meeds#1181

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/command/NotificationExecutorImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/command/NotificationExecutorImpl.java
@@ -66,7 +66,7 @@ public class NotificationExecutorImpl implements NotificationExecutor {
           if (notifiction != null) {
             notificationService.process(notifiction);
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           LOG.warn("Process NotificationInfo is failed: " + e.getMessage(), e);
           return false;
         } finally {


### PR DESCRIPTION
Before this fix, a StackOverflowError can be generated in notification creation. But as the catch is only on Exception, the StackOverflowError is not catch, and it is swallowed. This commit change the type of the exception catched to Throwable, so that the StackOverflowError can be catched and loggued.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
