### PR TITLE
fix: Task notification like mention are not displayed in site in certain case - EXO-66779 - meeds-io/meeds#1181 (#539)

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/command/NotificationExecutorImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/command/NotificationExecutorImpl.java
@@ -66,7 +66,7 @@ public class NotificationExecutorImpl implements NotificationExecutor {
           if (notifiction != null) {
             notificationService.process(notifiction);
           }
-        } catch (Exception e) {
+        } catch (Throwable e) {
           LOG.warn("Process NotificationInfo is failed: " + e.getMessage(), e);
           return false;
         } finally {


### PR DESCRIPTION
Before this fix, a StackOverflowError can be generated in notification creation. But as the catch is only on Exception, the StackOverflowError is not catch, and it is swallowed. This commit change the type of the exception catched to Throwable, so that the StackOverflowError can be catched and loggued.
