### PR TITLE
fix: fix ui issue on format and size dropdown options in editor toolbar - EXO-67425

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/contents.less
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/contents.less
@@ -153,7 +153,7 @@ a {
   color: @linkColor;
 }
 
-ol, ul, dl {
+ol, ul:not(.cke_panel_list), dl {
   margin: @listMargin !important;
   padding: @listPadding !important;
 }


### PR DESCRIPTION
fix ui issue on format and size dropdown options in editor toolbar by excluding the list of options from the styles applied on the editor content
