### PR TITLE
fix: Fix Notification language to use only supported languages - MEED-2897 - Meeds-io/meeds#1272

### DIFF
--- a/commons-api/src/test/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtilsTest.java
+++ b/commons-api/src/test/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtilsTest.java
@@ -51,7 +51,7 @@ public class NotificationPluginUtilsTest extends AbstractKernelTest {
     }
 
     language = NotificationPluginUtils.getLanguage(userName);
-    assertEquals(langFR_FR, language);
+    assertEquals(langFR, language);
   }
 
   public void testGetBrandingPortalName() throws Exception {


### PR DESCRIPTION
Prior to this change, when the stored user language wasn't supported by locale configuration, the returned locale was used. This change will ensure to use only supported locale configuration for notifications to avoid having missing I18N translation inside notifications.