### PR TITLE
fix: Fix color definition for Heading elements - MEED-3015 - Meeds-io/meeds#1335

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/contents.less
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/contents.less
@@ -10,9 +10,6 @@ body {
   font-size: @normalFontSize;
   overflow: auto;
 
-  /* Text color */
-  color: @normalFontColor;
-
   /* Remove the background color to make it transparent */
   background-color: transparent;
 


### PR DESCRIPTION
Prior to this change, a special color was applied to heading HTML elements in CKEditor. This change will delete the predefined color on CKEDitor body elements to use default one inherited from Core CSS.