### PR TITLE
feat: Link field Placeholder alignement and size - MEED-3078- Meeds-io/MIPs#107

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/balloontoolbar/skins/moono-exo/balloontoolbar.css
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/balloontoolbar/skins/moono-exo/balloontoolbar.css
@@ -45,11 +45,18 @@ CKEditor 4 LTS ("Long Term Support") is available under the terms of the Extende
 
 .cke_balloontoolbar.cke_inputTextBalloon .cke_balloon_close_button {
 	left:  10px!important;
-	top: 11px;
+	top: 10px;
 }
 
 .cke_balloontoolbar.cke_inputTextBalloon #inputURL {
 	height: 28px!important;
-    min-height: 28px!important;
+  min-height: 28px!important;
+  box-shadow: none !important;
+  font-size: 14px !important;
 }
+
+.cke_balloontoolbar.cke_inputTextBalloon #inputURL::placeholder {
+  font-size: 13px !important;
+}
+
 


### PR DESCRIPTION
This fix allow to adjust the CSS style of the input link balloon toolbar