### PR TITLE
feat: Fix error when selecting text and make it bold - MEED-3074- Meeds-io/MIPs#107

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/balloonpanel/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/balloonpanel/plugin.js
@@ -418,6 +418,7 @@
 							return item.getClientRects( true )[ 0 ];
 						} );
 					} else {
+						elementOrSelection.selectRanges([ranges[ ranges.length - 1 ]]);
 						rectList = ranges[ ranges.length - 1 ].getClientRects( true );
 					}
 


### PR DESCRIPTION
This changes allows to fix the js console error when selecting a text and make it bold/italic using the CKeditor balloon toolbar.