### PR TITLE
fix: CKeditor margin issues in font size and paragraph format dropdown lists - EXO-68267 - Meeds-io/meeds#1496

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/contents.less
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/contents.less
@@ -140,7 +140,7 @@ a {
   color: @linkColor !important;
 }
 
-ol, ul, dl {
+ol, ul:not(.cke_panel_list), dl {
   margin: @listMargin !important;
   padding: @listPadding !important;
 }


### PR DESCRIPTION
Before this change, when create or edit note and check the margins in the paragraph format and font size dropdown lists, There is a big margin in the dropdown lists. To resolve this problem, remove the css added to the ol and ul tags in dropdown lists in ckeditor. After this change, Remove the extra margins.