### PR TITLE
fix: anchor disappear in notes app for accentuated chars - EXO-68365 - Meeds-io/meeds#1495

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/link/dialogs/anchor.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/link/dialogs/anchor.js
@@ -15,7 +15,10 @@ CKEDITOR.dialog.add( 'anchor', function( editor ) {
 			attributes: attributes
 		} ), 'cke_anchor', 'anchor' );
 	}
-
+	
+	function removeAccents( name ) {
+		return name.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+	}
 
 	function getSelectedAnchor( selection ) {
 		var range = selection.getRanges()[ 0 ],
@@ -69,8 +72,9 @@ CKEDITOR.dialog.add( 'anchor', function( editor ) {
 			return getSelectedAnchor( editor.getSelection() ) || null;
 		},
 		onOk: function() {
-			var name = CKEDITOR.tools.trim( this.getValueOf( 'info', 'txtName' ) ),
-				attributes = {
+			var name = CKEDITOR.tools.trim( this.getValueOf( 'info', 'txtName' ) );
+			name = removeAccents(name);
+			var attributes = {
 					id: name,
 					name: name,
 					'data-cke-saved-name': name


### PR DESCRIPTION
Before this change, when create or edit note, add some lines in the body, select a text click on anchor icon in ckeditor, in Anchor Name type text containing accents, save note and edit note, anchor containing accentuated chars disappear. To resolve this problem, remove the accentuted chars in the anchor name. After this change, anchors are well displayed with name without accents.

(cherry picked from commit c11f217f5dd8362c342fa479b1950956ed30a19a)