### PR TITLE
fix: allow reindexing indexes while upgrading - EXO-64127 - Meeds-io/meeds#1631

### DIFF
--- a/commons-search/pom.xml
+++ b/commons-search/pom.xml
@@ -29,7 +29,7 @@
   <packaging>jar</packaging>
   <name>eXo PLF:: Commons - Commons Search</name>
   <properties>
-    <exo.test.coverage.ratio>0.33</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.4</exo.test.coverage.ratio>
     <org.hamcrest.version>1.3</org.hamcrest.version>
   </properties>
   <dependencies>

--- a/commons-search/src/main/java/org/exoplatform/commons/search/domain/OperationType.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/domain/OperationType.java
@@ -10,7 +10,8 @@ public enum OperationType {
   INIT("I"),
   CREATE("C"),
   UPDATE("U"),
-  DELETE("D");
+  DELETE("D"),
+  DELETE_ALL("X");
 
   private final String operationId;
 

--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/client/ElasticIndexingAuditTrail.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/client/ElasticIndexingAuditTrail.java
@@ -13,6 +13,8 @@ import org.exoplatform.services.log.Log;
 public class ElasticIndexingAuditTrail {
   public static final String  REINDEX_ALL         = "reindex_all";
 
+  public static final String  DELETE_ALL          = "delete_all";
+
   public static final String  CREATE_INDEX        = "create_index";
 
   public static final String  DELETE_INDEX        = "delete_index";

--- a/commons-search/src/main/java/org/exoplatform/commons/search/es/client/ElasticSearchingClient.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/es/client/ElasticSearchingClient.java
@@ -39,26 +39,6 @@ public class ElasticSearchingClient extends ElasticClient {
     initHttpClient();
   }
 
-  /**
-   * No need to ES Type anymore, this method will be removed
-   * shortly
-   * 
-   * @param esQuery
-   * @param index
-   * @param type
-   * @return
-   */
-  @Deprecated
-  public String sendRequest(String esQuery, String index, String type) {
-    if (LOG.isDebugEnabled()) {
-      // Display stack trace
-      LOG.warn(new IllegalStateException("This method has been deprecated and will be removed in future releases."));
-    } else {
-      LOG.warn("This method has been deprecated and will be removed in future releases. To see stack trace, you can enable debug level on this class.");
-    }
-    return sendRequest(esQuery, index);
-  }
-
   public String sendRequest(String esQuery, String index) {
     long startTime = System.currentTimeMillis();
     StringBuilder url = new StringBuilder();

--- a/commons-search/src/main/java/org/exoplatform/commons/search/index/IndexingService.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/index/IndexingService.java
@@ -38,6 +38,4 @@ public interface IndexingService {
    * @LevelAPI Experimental
    */
   void unindex(String connectorName, String id);
-
-
 }

--- a/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingServiceConnector.java
@@ -50,7 +50,9 @@ public abstract class ElasticIndexingServiceConnector extends IndexingServiceCon
 
   protected String indexAlias;
   protected String currentIndex;
+  protected String previousIndex;
   protected String mapping;
+  protected boolean reindexOnUpgrade;
   protected Integer shards = SHARDS_NUMBER_DEFAULT;
   protected Integer replicas = REPLICAS_NUMBER_DEFAULT;
 
@@ -58,6 +60,8 @@ public abstract class ElasticIndexingServiceConnector extends IndexingServiceCon
     PropertiesParam param = initParams.getPropertiesParam("constructor.params");
 
     this.currentIndex = param.getProperty("index_current");
+    this.previousIndex = param.getProperty("index_previous");
+    String reindexOnUpgradeString = param.getProperty("reindexOnUpgrade");
     if (StringUtils.isBlank(this.currentIndex)) {
       throw new IllegalStateException("Connector ES index name is mandatory.");
     }
@@ -65,6 +69,8 @@ public abstract class ElasticIndexingServiceConnector extends IndexingServiceCon
     if (StringUtils.isBlank(indexAlias)) {
       this.indexAlias = this.currentIndex;
     }
+    this.reindexOnUpgrade = StringUtils.isNotBlank(reindexOnUpgradeString) && reindexOnUpgradeString.trim().equalsIgnoreCase("true");
+
 
     //Get number of replicas in connector declaration or exo properties
     if (StringUtils.isNotBlank(param.getProperty("replica.number"))) {
@@ -129,6 +135,18 @@ public abstract class ElasticIndexingServiceConnector extends IndexingServiceCon
 
   public String getCurrentIndex() {
     return currentIndex;
+  }
+
+  public String getPreviousIndex() {
+    return previousIndex;
+  }
+
+  public void setPreviousIndex(String previousIndex) {
+    this.previousIndex = previousIndex;
+  }
+
+  public boolean isReindexOnUpgrade() {
+    return reindexOnUpgrade;
   }
 
   public String getIndexAlias() {

--- a/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/QueueIndexingService.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/QueueIndexingService.java
@@ -51,7 +51,7 @@ public class QueueIndexingService implements IndexingService {
     }
     addToIndexingQueue(connectorName, id, OperationType.DELETE);
   }
-
+  
   /**
    * Add a new operation to the create queue
    * @param connectorName Name of the connector


### PR DESCRIPTION
Before this fix, there was a need to an upgrade plugin to perform the upgrade of indexes.
This fixes restores an old behaviour that allows to define a new index **currentIndex** to which a migration will be performed from **previousIndex**.
There will be also the possibility to reindex all data based on the parameter **reindexOnUpgrade** that could be added to the IndexingServiceConnector.