### PR TITLE
fix: Trim white spaces from links on embed media insertion - EXO-69832 - Meeds-io/meeds#1703.

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/embedbase/dialogs/embedbase.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/embedbase/dialogs/embedbase.js
@@ -29,7 +29,7 @@ CKEDITOR.dialog.add( 'embedBase', function( editor ) {
 				// Indicate visually that waiting for the response (https://dev.ckeditor.com/ticket/13213).
 				that.setState( CKEDITOR.DIALOG_STATE_BUSY );
 
-				var url = that.getValueOf( 'info', 'url' ),
+				var url = that.getValueOf( 'info', 'url' ).trim(),
 					widget = that.getModel( editor );
 
 				loadContentRequest = widget.loadContent( url, {


### PR DESCRIPTION

Before this change, when click on insert media from ckeditor, add white space at the front then paste a media link(video or image) and click on ok, the specified URL is not supported. After this change, this media is downloaded correctly.