### PR TITLE
fix: Trim white spaces from links on embed media insertion - EXO-69832 - Meeds-io/meeds#1703

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/embedbase/dialogs/embedbase.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/embedbase/dialogs/embedbase.js
@@ -87,7 +87,7 @@ CKEDITOR.dialog.add( 'embedBase', function( editor ) {
 
 						validate: function() {
 							var widget = this.getDialog().getModel( editor );
-
+							this.setValue(this.getValue().trim());
 							if ( !widget.isUrlValid( this.getValue() ) ) {
 								return lang.unsupportedUrlGiven;
 							}


### PR DESCRIPTION
Before this change, when click on insert media from ckeditor, add white space at the front then paste a media link(video or image) and click on ok, the specified URL is not supported. After this change, this media is downloaded correctly.

(cherry picked from commit 79279b049af87460a77775ecb6b4453b0c9d3ec6)