### PR TITLE
fix : Problem when using reindexOnUpgrade and pipeline - EXO-70223

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingOperationProcessor.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingOperationProcessor.java
@@ -768,7 +768,7 @@ public class ElasticIndexingOperationProcessor extends IndexingOperationProcesso
                   indexingServiceConnector.getPreviousIndex(),
                   indexingServiceConnector.getCurrentIndex());
           try {
-            elasticIndexingClient.sendReindexTypeRequest(indexingServiceConnector.getCurrentIndex(), indexingServiceConnector.getPreviousIndex(), indexingServiceConnector.getPipelineName());
+            elasticIndexingClient.sendReindexTypeRequest(indexingServiceConnector.getCurrentIndex(), indexingServiceConnector.getPreviousIndex(), indexingServiceConnector.getReindexPipelineName());
             if(this.indexingServiceConnector.isReindexOnUpgrade()) {
               ExoContainerContext.setCurrentContainer(exoContainer);
               reindexAllByEntityIndex(indexingServiceConnector.getConnectorName());

--- a/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingServiceConnector.java
@@ -181,6 +181,9 @@ public abstract class ElasticIndexingServiceConnector extends IndexingServiceCon
   public String getPipelineName() {
     return null;
   }
+  public String getReindexPipelineName() {
+    return null;
+  }
 
   public String getAttachmentProcessor() {
     return null;


### PR DESCRIPTION
Before this fix, when trying to create a new index by upgrade, and using a pipeline, ES complains of an error.

This is due to the fact that the pipeline can, at the end, delete a property. And then when using _reindex ES function (which copy the data from one index to another), this property is missing.

This commit allow to no use pipeline when calling _reindex ES function, in case of the pipeline removes a field.

Resolves meeds-io/meeds#1755

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
