### PR TITLE
fix : Problem when using reindexOnUpgrade and pipeline - EXO-70223

### DIFF
--- a/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingOperationProcessor.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingOperationProcessor.java
@@ -768,7 +768,7 @@ public class ElasticIndexingOperationProcessor extends IndexingOperationProcesso
                   indexingServiceConnector.getPreviousIndex(),
                   indexingServiceConnector.getCurrentIndex());
           try {
-            elasticIndexingClient.sendReindexTypeRequest(indexingServiceConnector.getCurrentIndex(), indexingServiceConnector.getPreviousIndex(), indexingServiceConnector.getPipelineName());
+            elasticIndexingClient.sendReindexTypeRequest(indexingServiceConnector.getCurrentIndex(), indexingServiceConnector.getPreviousIndex(), indexingServiceConnector.getReindexPipelineName());
             if(this.indexingServiceConnector.isReindexOnUpgrade()) {
               ExoContainerContext.setCurrentContainer(exoContainer);
               reindexAllByEntityIndex(indexingServiceConnector.getConnectorName());

--- a/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingServiceConnector.java
+++ b/commons-search/src/main/java/org/exoplatform/commons/search/index/impl/ElasticIndexingServiceConnector.java
@@ -181,6 +181,9 @@ public abstract class ElasticIndexingServiceConnector extends IndexingServiceCon
   public String getPipelineName() {
     return null;
   }
+  public String getReindexPipelineName() {
+    return null;
+  }
 
   public String getAttachmentProcessor() {
     return null;


### PR DESCRIPTION
Before this fix, when trying to create a new index by upgrade, and using a pipeline, ES complains of an error.

This is due to the fact that the pipeline can, at the end, delete a property. And then when using _reindex ES function (which copy the data from one index to another), this property is missing.

This commit allow to no use pipeline when calling _reindex ES function, in case of the pipeline removes a field.

Resolves meeds-io/meeds#1755