### PR TITLE
feat:  No embedded anymore for links in comment except video - MEED-4547 - Meeds-io/MIPs#124

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/embedbase/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/embedbase/plugin.js
@@ -423,9 +423,12 @@
 					if ( request.task ) {
 						request.task.done();
 					}
-
-					this._setContent( request.url, evtData.html );
-					return true;
+					if ( editor.name.indexOf('comment_') > -1 && request.response.type !== 'video' ) {
+						return false
+					} else {
+						this._setContent( request.url, evtData.html );
+						return true;
+					}
 				} else {
 					request.errorCallback( evtData.errorMessage );
 					return false;


### PR DESCRIPTION
This change prevents the display of embedded links in activity comments, except for video links