### PR TITLE
fix: When username have email format, field from and to of the email are not correct - EXO-72048

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
@@ -96,10 +96,6 @@ public class NotificationPluginUtils {
   }
 
   public static String getFrom(String from) {
-    if (from != null && from.length() > 0 && from.indexOf("@") > 0) {
-      return from;
-    }
-
     return new StringBuffer(MailUtils.getSenderName()).append("<").append(MailUtils.getSenderEmail()).append(">").toString();
   }
 
@@ -112,7 +108,12 @@ public class NotificationPluginUtils {
   }
   
   public static String getTo(String to) {
-    return isValidEmail(to) ? to : getEmailFormat(to);
+    String email = getEmailFormat(to);
+    if (email!=null) {
+      return email;
+    } else {
+      return isValidEmail(to) ? to : null;
+    }
   }
 
   public static boolean isValidEmail(String to) {


### PR DESCRIPTION
Before this fix, when the username have email format, there are 2 problems :
- the field from is not the field define in notification administration (noreply@...) but the username of the sender (which have an email format)
- The field to is the username to the receiver instead of his email

This commit ensure to always use the noreply (or the email defined in notification admnistration), and the receiver email, and not username

Resolved https://github.com/Meeds-io/meeds/issues/2061