### PR TITLE
fix: When username have email format, field from and to of the email are not correct - EXO-72048

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/plugin/NotificationPluginUtils.java
@@ -96,10 +96,6 @@ public class NotificationPluginUtils {
   }
 
   public static String getFrom(String from) {
-    if (from != null && from.length() > 0 && from.indexOf("@") > 0) {
-      return from;
-    }
-
     return new StringBuffer(MailUtils.getSenderName()).append("<").append(MailUtils.getSenderEmail()).append(">").toString();
   }
 
@@ -112,7 +108,12 @@ public class NotificationPluginUtils {
   }
   
   public static String getTo(String to) {
-    return isValidEmail(to) ? to : getEmailFormat(to);
+    String email = getEmailFormat(to);
+    if (email!=null) {
+      return email;
+    } else {
+      return isValidEmail(to) ? to : null;
+    }
   }
 
   public static boolean isValidEmail(String to) {


### PR DESCRIPTION
Before this fix, when the username have email format, there are 2 problems :
- the field from is not the field define in notification administration (noreply@...) but the username of the sender (which have an email format)
- The field to is the username to the receiver instead of his email

This commit ensure to always use the noreply (or the email defined in notification admnistration), and the receiver email, and not username

Resolved meeds-io/meeds#2061

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
