### PR TITLE
fix: Delete useless ResourceRequestFilter mappings - MEED-7004 - Meeds-io/meeds#2109

### DIFF
--- a/commons-comet-webapp/src/main/webapp/WEB-INF/jboss-web.xml
+++ b/commons-comet-webapp/src/main/webapp/WEB-INF/jboss-web.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<jboss-web version="7.2"
-           xmlns="http://www.jboss.com/xml/ns/javaee"
-           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee schema/jboss-web_7_2.xsd">
-  <enable-websockets>true</enable-websockets>
-</jboss-web>

--- a/commons-comet-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/commons-comet-webapp/src/main/webapp/WEB-INF/web.xml
@@ -14,7 +14,10 @@
 
   <filter-mapping>
     <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>/*</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>/images/*</url-pattern>
   </filter-mapping>
 
   <servlet>

--- a/commons-extension-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/commons-extension-webapp/src/main/webapp/WEB-INF/web.xml
@@ -28,6 +28,9 @@
       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
   <display-name>commons-extension</display-name>
+
+  <absolute-ordering/>
+
   <listener>
     <listener-class>org.exoplatform.container.web.PortalContainerConfigOwner</listener-class>
   </listener>
@@ -39,8 +42,13 @@
 
   <filter-mapping>
     <filter-name>ResourceRequestFilter</filter-name>
-    <url-pattern>/*</url-pattern>
+    <url-pattern>*.css</url-pattern>
+    <url-pattern>*.js</url-pattern>
+    <url-pattern>*.html</url-pattern>
+    <url-pattern>*.png</url-pattern>
+    <url-pattern>*.ico</url-pattern>
+    <url-pattern>*.webp</url-pattern>
+    <url-pattern>/images/*</url-pattern>
   </filter-mapping>
 
-  <absolute-ordering/>
 </web-app>


### PR DESCRIPTION
Prior to this change, any URL was cached while the Cache HTTP Header should be applied systematically on static resources only. This change changes the Filter mapping list in order to include static resources only.

(Resolves Meeds-io/meeds#2109)