### PR TITLE
fix: Fix table cell resize when the cell contains an image - EXO-72407 - Meeds-io/meeds#2143

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/tableresize/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/tableresize/plugin.js
@@ -266,7 +266,7 @@
 			editor.fire( 'saveSnapshot' );
 			resizeStart();
 
-			document.on( 'mouseup', onMouseUp, this );
+			document.on( 'pointerup', onMouseUp, this );
 		}
 
 		function onMouseUp( evt ) {


### PR DESCRIPTION
Fix table cell resize when the cell contains an image
fixes #616 