### PR TITLE
fix: Image Resize not working for some specific images - EXO-74160

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/services/thumbnail/ImageResizeServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/services/thumbnail/ImageResizeServiceImpl.java
@@ -24,8 +24,10 @@ import java.util.Iterator;
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
+import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.ImageInputStream;
 
 import org.imgscalr.Scalr;
@@ -111,7 +113,11 @@ public class ImageResizeServiceImpl implements ImageResizeService {
     writer.setOutput(ImageIO.createImageOutputStream(byteArrayOutputStream));
 
     IIOMetadata metadata = sourceImageReader.getImageMetadata(0);
-    writer.write(new IIOImage(targetBufferedImage, null, metadata));
+    ImageWriteParam param = writer.getDefaultWriteParam();
+    if (param instanceof JPEGImageWriteParam) {
+      ((JPEGImageWriteParam) param).setOptimizeHuffmanTables(true);
+    }
+    writer.write(null,new IIOImage(targetBufferedImage, null, metadata), param);
     writer.dispose();
     return byteArrayOutputStream.toByteArray();
   }


### PR DESCRIPTION
Before this fix, in some particular case, images cannot be resized. This fix add option to correctly write the image for resize

Resolves meeds-io/meeds#2386

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
