### PR TITLE
fix: Image Resize not working for some specific images - EXO-74160

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/services/thumbnail/ImageResizeServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/services/thumbnail/ImageResizeServiceImpl.java
@@ -24,8 +24,10 @@ import java.util.Iterator;
 import javax.imageio.IIOImage;
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
+import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.metadata.IIOMetadata;
+import javax.imageio.plugins.jpeg.JPEGImageWriteParam;
 import javax.imageio.stream.ImageInputStream;
 
 import org.imgscalr.Scalr;
@@ -111,7 +113,11 @@ public class ImageResizeServiceImpl implements ImageResizeService {
     writer.setOutput(ImageIO.createImageOutputStream(byteArrayOutputStream));
 
     IIOMetadata metadata = sourceImageReader.getImageMetadata(0);
-    writer.write(new IIOImage(targetBufferedImage, null, metadata));
+    ImageWriteParam param = writer.getDefaultWriteParam();
+    if (param instanceof JPEGImageWriteParam) {
+      ((JPEGImageWriteParam) param).setOptimizeHuffmanTables(true);
+    }
+    writer.write(null,new IIOImage(targetBufferedImage, null, metadata), param);
     writer.dispose();
     return byteArrayOutputStream.toByteArray();
   }


### PR DESCRIPTION
Before this fix, in some particular case, images cannot be resized. This fix add option to correctly write the image for resize

Resolves meeds-io/meeds#2386

(cherry picked from commit eca91ab3b9c61036ba3dbef933a04f5b3b98c0bf)