### PR TITLE
feat: Fix increase/decrease indentation not working correctly in CKEditor - EXO-73292 - Meeds-io/MIPs#129

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/indentblock/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/indentblock/plugin.js
@@ -237,8 +237,13 @@
 				currentOffset ? currentOffset + ( editor.config.indentUnit || 'px' ) : ''
 			);
 
-			if ( element.getAttribute( 'style' ) === '' )
+			if ( element.getAttribute( 'style' ) !== '' ) {
+				let currentStyle = element.getAttribute('style');
+				currentStyle = currentStyle.substring(0, currentStyle.length - 1 ).concat(' !important;')
+				element.setAttribute('style', currentStyle);
+			} else {
 				element.removeAttribute( 'style' );
+			}
 		}
 
 		CKEDITOR.dom.element.setMarker( this.database, element, 'indent_processed', 1 );


### PR DESCRIPTION
Prior to this change, block indentation was not applied to numbered lists due to the CSS margin style property not being applied to the indented elements. This change adds the !important property to the element's style, resolving the issue.