### PR TITLE
feat: Fix the copied format not being applied to the selected text in some CKEditor instances - EXO-73291 - Meeds-io/MIPs#129

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/copyformatting/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/copyformatting/plugin.js
@@ -109,6 +109,15 @@
 					}
 				} );
 
+				if (mouseupHost === editor.document) {
+					editable.attachListener( editable, 'mouseup', function( evt ) {
+						// Apply formatting only if any styles are copied (#2780, #2655, #2470).
+						if ( getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT && cmd.state === CKEDITOR.TRISTATE_ON ) {
+							editor.execCommand( 'applyFormatting' );
+						}
+					} );
+				}
+
 				editable.attachListener( CKEDITOR.document, 'mouseup', function( evt ) {
 					if ( getMouseButton( evt ) === CKEDITOR.MOUSE_BUTTON_LEFT && cmd.state === CKEDITOR.TRISTATE_ON &&
 						!editable.contains( evt.data.getTarget() ) ) {


### PR DESCRIPTION

Prior to this change, the copied format was not applied to the selected text in some CKEditor instances. This issue was due to the mouseup event being attached to the editor document and not being detected. This change attaches the entire event to the editor's editable element, resolving the issue.