### PR TITLE
feat: Update calls to UserACL to avoid implicit usage of ConversationState in Service Layer - MEED-7555 - Meeds-io/MIPs#151

### DIFF
--- a/commons-component-product/src/main/java/org/exoplatform/commons/info/PlatformInformationRESTService.java
+++ b/commons-component-product/src/main/java/org/exoplatform/commons/info/PlatformInformationRESTService.java
@@ -30,6 +30,7 @@ import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.rest.resource.ResourceContainer;
+import org.exoplatform.services.security.ConversationState;
 
 /**
  * @author <a href="mailto:anouar.chattouna@exoplatform.com">Anouar
@@ -72,7 +73,7 @@ public class PlatformInformationRESTService implements ResourceContainer {
       String plfProfile = ExoContainer.getProfiles().toString().trim();
       String runningProfile = plfProfile.substring(1, plfProfile.length() - 1);
       JsonPlatformInfo jsonPlatformInfo = new JsonPlatformInfo();
-      if (userACL.isUserInGroup(userACL.getAdminGroups())) {
+      if (userACL.isAdministrator(ConversationState.getCurrent().getIdentity())) {
         jsonPlatformInfo.setPlatformVersion(platformInformations.getVersion());
         jsonPlatformInfo.setPlatformBuildNumber(platformInformations.getBuildNumber());
         jsonPlatformInfo.setPlatformRevision(platformInformations.getRevision());


### PR DESCRIPTION
This change will update `UserACL` usage to not implicitly use the current conversation state of authenticated user in `UserACL` (ServiceLayer).