### PR TITLE
feat: Allow To use ngram_tokenizer when indexing a Field - MEED-7667 - Meeds-io/meeds#2523

### DIFF
--- a/commons-search/src/main/resources/es-default-index-settings.json
+++ b/commons-search/src/main/resources/es-default-index-settings.json
@@ -12,6 +12,14 @@
                "asciifolding"
             ]
          },
+         "ngram_analyzer":{
+            "type":"custom",
+            "tokenizer":"ngram_tokenizer",
+            "filter":[
+               "lowercase",
+               "asciifolding"
+            ]
+         },
          "letter_lowercase_asciifolding":{
             "type":"custom",
             "tokenizer":"letter",
@@ -37,6 +45,17 @@
             ],
             "char_filter": [
                "html_strip"
+            ]
+         }
+      },
+      "tokenizer":{
+         "ngram_tokenizer":{
+            "type":"ngram",
+            "min_gram": 3,
+            "max_gram": 3,
+            "token_chars":[
+               "letter",
+               "digit"
             ]
          }
       }


### PR DESCRIPTION
This change will allow to index a field in order to use an autocomplete behavior with partial matching of a word.