### PR TITLE
feat: Allow figcaption in HTML sanitizer display preloaded height and width in the image properties dialog - EXO-75213 - Meeds-io/MIPs154

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
@@ -346,6 +346,10 @@ abstract public class HTMLSanitizer {
                                                                                                                                         "exo-wiki-include-page",
                                                                                                                                         "iframe")
                                                                                                                                 .allowAttributes("page-name").onElements("exo-wiki-include-page")
+                                                                                                                                .allowElements("figcaption")
+                                                                                                                                .allowAttributes("class")
+                                                                                                                                .matching(HTML_CLASS)
+                                                                                                                                .onElements("figcaption")
                                                                                                                                  //Allows the named elements for xwiki input
                                                                                                                                 .allowElements("wikiimage","wikilink","wikimacro")
                                                                                                                                 .allowAttributes("wikiparam")

--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/image2/dialogs/image2.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/image2/dialogs/image2.js
@@ -405,6 +405,16 @@ CKEDITOR.dialog.add( 'image2', function( editor ) {
 
 			// Get the natural height of the image.
 			preLoadedHeight = domHeight = natural.height;
+
+			// set the preloaded values if no defined values
+			if (!widget?.data?.width) {
+				widget.setData( 'width',  preLoadedWidth);
+			}
+
+			if (!widget?.data?.height) {
+				widget.setData( 'height',  preLoadedHeight);
+			}
+
 		},
 		contents: [
 			{


### PR DESCRIPTION
This change  allows the figcaption HTML tag  in the HTML sanitizer and displays the natural image with and height in the image properties dialog upon the first opening.