### PR TITLE
feat: Fix image resizing issue - EXO-74758 - Meeds-io/MIPs#145

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/plugins/image2/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/plugins/image2/plugin.js
@@ -1179,7 +1179,7 @@
 			attachToDocuments( 'mousemove', onMouseMove, listeners );
 
 			// Clean up the mousemove listener. Update widget data if valid.
-			attachToDocuments( 'mouseup', onMouseUp, listeners );
+			attachToDocuments( 'pointerup', onMouseUp, listeners );
 
 			// The entire editable will have the special cursor while resizing goes on.
 			editable.addClass( cursorClass );


### PR DESCRIPTION
Prior to this change, resizing an inserted image in the editor was not possible. The resizer remained attached to the mouse and only detached when clicking outside the editor. This change addresses the issue by attaching the pointerup event to the document instead of the mouseup event