### PR TITLE
feat: Allow Content Link Html Tag - MEED-8934 - Meeds-io/MIPs#192

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/HTMLSanitizer.java
@@ -18,7 +18,6 @@
  */
 package org.exoplatform.commons.utils;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -31,7 +30,6 @@ import org.owasp.html.*;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
-import com.google.common.base.Throwables;
 
 /**
  * Prevent XSS/XEE attacks by encoding user HTML inputs. This class will be used
@@ -140,6 +138,8 @@ abstract public class HTMLSanitizer {
                                                                                                                                 .allowAttributes("data-identity-id")
                                                                                                                                 .globally()
                                                                                                                                 .allowAttributes("data-role")
+                                                                                                                                .globally()
+                                                                                                                                .allowAttributes("data-object")
                                                                                                                                 .globally()
                                                                                                                                 .allowAttributes("nohref")
                                                                                                                                 .onElements("a")
@@ -344,6 +344,7 @@ abstract public class HTMLSanitizer {
                                                                                                                                         "ins",
                                                                                                                                         "exo-wiki-children-pages",
                                                                                                                                         "exo-wiki-include-page",
+                                                                                                                                        "content-link",
                                                                                                                                         "iframe")
                                                                                                                                 .allowAttributes("page-name").onElements("exo-wiki-include-page")
                                                                                                                                 .allowElements("figcaption")
@@ -374,28 +375,19 @@ abstract public class HTMLSanitizer {
    * 
    * @param html The <code>String</code> object
    * @return The sanitized HTML to store in DB layer
-   * @throws Exception
    */
-  public static String sanitize(String html) throws Exception {
+  public static String sanitize(String html) {
     StringBuilder sb = new StringBuilder();
     // Set up an output channel to receive the sanitized HTML.
     HtmlStreamRenderer renderer = HtmlStreamRenderer.create(sb,
-    // Receives notifications on a failure to write to the output.
-                                                            new Handler<IOException>() {
-                                                              public void handle(IOException ex) {
-                                                                Throwables.propagate(ex);
-                                                              }
-                                                            },
                                                             // Our HTML parser
                                                             // is very lenient,
                                                             // but this receives
                                                             // notifications on
                                                             // truly bizarre
                                                             // inputs.
-                                                            new Handler<String>() {
-                                                              public void handle(String x) {
-                                                                throw new AssertionError(x);
-                                                              }
+                                                            x -> {
+                                                              throw new AssertionError(x);
                                                             });
 
     // Use the policy defined above to sanitize the HTML.


### PR DESCRIPTION
This change will allow to preserve Content Link specific Tag in HTML contents while using sanitizer.