### PR TITLE
feat: Extract Mail Template Content Processing into a Service - MEED-9059 - Meeds-io/MIPs#192

### DIFF
--- a/commons-api/pom.xml
+++ b/commons-api/pom.xml
@@ -111,6 +111,12 @@
       <artifactId>imgscalr-lib</artifactId>
     </dependency>
 
+    <!-- Used by Notification Utils -->
+    <dependency>
+      <groupId>org.jsoup</groupId>
+      <artifactId>jsoup</artifactId>
+    </dependency>
+
     <!-- Test scope -->
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/template/TemplateContentTransformerService.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/template/TemplateContentTransformerService.java
@@ -1,0 +1,131 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.commons.notification.template;
+
+import static org.exoplatform.commons.notification.template.TemplateUtils.getExcerptSubject;
+import static org.exoplatform.commons.notification.template.TemplateUtils.getPluginConfig;
+import static org.exoplatform.commons.notification.template.TemplateUtils.loadGroovyElement;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+
+import org.exoplatform.commons.api.notification.plugin.config.PluginConfig;
+import org.exoplatform.commons.api.notification.service.template.TemplateContext;
+import org.exoplatform.commons.api.notification.template.Element;
+import org.exoplatform.commons.api.notification.template.ElementVisitor;
+import org.exoplatform.commons.notification.NotificationUtils;
+import org.exoplatform.services.cache.CacheService;
+import org.exoplatform.services.cache.ExoCache;
+
+public class TemplateContentTransformerService {
+
+  private static final String       DIGEST_TEMPLATE_KEY = "Digest.%s.%s";
+
+  private static final String       SIMPLE_TEMPLATE_KEY = "Simple.%s.%s";
+
+  private ExoCache<String, Element> cacheTemplate;
+
+  public TemplateContentTransformerService(CacheService cacheService) {
+    this.cacheTemplate = cacheService.getCacheInstance("commons.subject");
+  }
+
+  /**
+   * Transform a {@link TemplateContext} with groovy template to a Text (used in
+   * Mail Notif by example)
+   * 
+   * @param ctx {@link TemplateContext}
+   * @return String result after executing Groovy Template content
+   */
+  public String processGroovy(TemplateContext ctx) {
+    Element groovyElement = loadGroovyElement(ctx.getPluginId(), ctx.getLanguage());
+    ElementVisitor visitor = new GroovyElementVisitor();
+    return visitor.with(ctx).visit(groovyElement).out();
+  }
+
+  /**
+   * Transform a {@link TemplateContext} to a Subject Text (used in Mail by
+   * example)
+   * 
+   * @param ctx {@link TemplateContext}
+   * @return Subject
+   */
+  public String processSubject(TemplateContext ctx) {
+    Element subjectElement = getSubjectElement(ctx);
+    ctx.forEach((k, v) -> {
+      if (v instanceof String s) {
+        ctx.put(k, transform(s, ctx));
+      }
+    });
+    String subject = getSubject(ctx);
+    if (StringUtils.isNotBlank(subject)) {
+      ctx.put("SUBJECT", getExcerptSubject(subject));
+      return subjectElement.accept(SimpleElementVistior.instance().with(ctx)).out();
+    } else {
+      subject = subjectElement.accept(SimpleElementVistior.instance().with(ctx)).out();
+      return getExcerptSubject(subject);
+    }
+  }
+
+  /**
+   * Render for digest template
+   * 
+   * @param ctx {@link TemplateContext} containing all Template Variables to use
+   *          for processing Template
+   * @return digest HTML content
+   */
+  public String processDigest(TemplateContext ctx) {
+    DigestTemplate digest = getDigestTemplate(ctx);
+    return digest.accept(SimpleElementVistior.instance().with(ctx)).out();
+  }
+
+  protected String getSubject(TemplateContext ctx) {
+    return transform((String) ctx.get("SUBJECT"), ctx);
+  }
+
+  protected String transform(String value, TemplateContext ctx) { // NOSONAR
+    return value == null ? null : StringEscapeUtils.unescapeHtml4(value);
+  }
+
+  private DigestTemplate getDigestTemplate(TemplateContext ctx) {
+    String key = getCacheKey(DIGEST_TEMPLATE_KEY, ctx.getPluginId(), ctx.getLanguage());
+    DigestTemplate digest = (DigestTemplate) cacheTemplate.get(key);
+    if (digest == null) {
+      PluginConfig templateConfig = getPluginConfig(ctx.getPluginId());
+      digest = NotificationUtils.getDigest(templateConfig, ctx.getPluginId(), ctx.getLanguage());
+      cacheTemplate.put(key, digest);
+    }
+    return digest;
+  }
+
+  private Element getSubjectElement(TemplateContext ctx) {
+    String key = getCacheKey(SIMPLE_TEMPLATE_KEY, ctx.getPluginId(), ctx.getLanguage());
+    Element subjectElement = cacheTemplate.get(key);
+    if (subjectElement == null) {
+      PluginConfig templateConfig = getPluginConfig(ctx.getPluginId());
+      subjectElement = NotificationUtils.getSubject(templateConfig, ctx.getPluginId(), ctx.getLanguage()).addNewLine(false);
+      cacheTemplate.put(key, subjectElement);
+    }
+    return subjectElement;
+  }
+
+  protected String getCacheKey(String pattern, String pluginId, String language) {
+    return String.format(pattern, pluginId, language);
+  }
+
+}

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/template/TemplateUtils.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/template/TemplateUtils.java
@@ -17,104 +17,75 @@
 package org.exoplatform.commons.notification.template;
 
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.StringWriter;
-import java.net.URL;
-import java.text.MessageFormat;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
-import java.util.Map;
 import java.util.ResourceBundle;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.StringEscapeUtils;
+import org.jsoup.Jsoup;
 
 import org.exoplatform.commons.api.notification.plugin.config.PluginConfig;
 import org.exoplatform.commons.api.notification.plugin.config.TemplateConfig;
 import org.exoplatform.commons.api.notification.service.template.TemplateContext;
 import org.exoplatform.commons.api.notification.template.Element;
-import org.exoplatform.commons.api.notification.template.ElementVisitor;
-import org.exoplatform.commons.notification.NotificationUtils;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.configuration.ConfigurationManager;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.services.resources.ResourceBundleService;
-import org.gatein.common.io.IOTools;
+
+import lombok.SneakyThrows;
 
 public class TemplateUtils {
-  private static final Log LOG = ExoLogger.getLogger(TemplateUtils.class);
-  private static final String DIGEST_TEMPLATE_KEY = "Digest.{0}.{1}";
-  private static final String SIMPLE_TEMPLATE_KEY = "Simple.{0}.{1}";
-  private static final Pattern SCRIPT_REMOVE_PATTERN = Pattern.compile("<(script|style)[^>]*>[^<]*</(script|style)>", Pattern.CASE_INSENSITIVE);
-  private static final Pattern TAGS_REMOVE_PATTERN = Pattern.compile("<[^>]*>", Pattern.CASE_INSENSITIVE);
 
-  private static Map<String, Element> cacheTemplate = new ConcurrentHashMap<String, Element>();
-  
+  private static final Log LOG                = ExoLogger.getLogger(TemplateUtils.class);
+
   private static final int MAX_SUBJECT_LENGTH = 50;
-  
+
   /**
-   * Process the Groovy template associate with Template context to generate
-   * It will be use for digest mail
+   * Process the Groovy template associate with Template context to generate It
+   * will be use for digest mail
+   * 
    * @param ctx
    * @return
    */
   public static String processGroovy(TemplateContext ctx) {
-    Element groovyElement = loadGroovyElement(ctx.getPluginId(), ctx.getLanguage());
-    
-    ElementVisitor visitor = new GroovyElementVisitor();
-    String content = visitor.with(ctx).visit(groovyElement).out();
-    return content;
+    return ExoContainerContext.getService(TemplateContentTransformerService.class).processGroovy(ctx);
   }
-  
+
   /**
-   * Gets InputStream for groovy template
+   * Render for Subject template
    * 
-   * @param templatePath
+   * @param ctx
    * @return
-   * @throws Exception
    */
-  private static InputStream getTemplateInputStream(String templatePath) throws Exception {
-    try {
-      
-      ConfigurationManager configurationManager =  CommonsUtils.getService(ConfigurationManager.class);
-      
-      String uri = templatePath;
-      if (templatePath.indexOf("war") < 0 && templatePath.indexOf("jar") < 0 && templatePath.indexOf("classpath") < 0) {
-        URL url = null;
-        if (templatePath.indexOf("/") == 0) {
-          templatePath = templatePath.substring(1);
-        }
-        uri = "war:/" + templatePath;
-        url = configurationManager.getURL(uri);
-        if (url == null) {
-          uri = "jar:/" + templatePath;
-          url = configurationManager.getURL(uri);
-        }
-      }
-      return configurationManager.getInputStream(uri);
-    } catch (Exception e) {
-      throw new RuntimeException("Error to get notification template " + templatePath, e);
-    }
+  public static String processSubject(TemplateContext ctx) {
+    return ExoContainerContext.getService(TemplateContentTransformerService.class).processSubject(ctx);
+  }
+
+  /**
+   * Render for digest template
+   * 
+   * @param ctx
+   * @return
+   */
+  public static String processDigest(TemplateContext ctx) {
+    return ExoContainerContext.getService(TemplateContentTransformerService.class).processDigest(ctx);
   }
 
   /**
    * Loads the Groovy template file
    * 
    * @param templatePath
-   * @return
-   * @throws Exception
+   * @return Groovy Template File content
    */
-  public static String loadGroovyTemplate(String templatePath) throws Exception {
-    Reader reader = null;
-    try {
-      StringWriter stringWriter = new StringWriter();
-      reader = new InputStreamReader(getTemplateInputStream(templatePath));
-      IOTools.copy(reader, stringWriter);
-      return stringWriter.toString();
+  public static String loadGroovyTemplate(String templatePath) {
+    try (InputStream inputStream = getTemplateInputStream(templatePath)) {
+      return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
     } catch (Exception e) {
       if (StringUtils.startsWith(templatePath, TemplateConfig.DEFAULT_SRC_RESOURCE_TEMPLATE_KEY)) {
         LOG.info("Failed to read default template file: {}. An empty message will be used", templatePath);
@@ -122,10 +93,6 @@ public class TemplateUtils {
         LOG.warn("Failed to read template file: {}. An empty message will be used", templatePath, e);
       }
       return "";
-    } finally {
-      if (reader != null) {
-        reader.close();
-      }
     }
   }
 
@@ -140,43 +107,11 @@ public class TemplateUtils {
     PluginConfig templateConfig = getPluginConfig(pluginId);
     return new GroovyElement().language(language).config(templateConfig);
   }
-  
-  /**
-   * Render for Subject template
-   * @param ctx
-   * @return
-   */
-  public static String processSubject(TemplateContext ctx) {
-    Element subjectElement = null;
-    String key = makeTemplateKey(SIMPLE_TEMPLATE_KEY, ctx.getPluginId(), ctx.getLanguage());
-    if (cacheTemplate.containsKey(key)) {
-      subjectElement = cacheTemplate.get(key);
-    } else {
-      PluginConfig templateConfig = getPluginConfig(ctx.getPluginId());
-      subjectElement = NotificationUtils.getSubject(templateConfig, ctx.getPluginId(), ctx.getLanguage()).addNewLine(false);
-      cacheTemplate.put(key, subjectElement);
-    }
-    
-    //The title of activity is escaped on social, then we need to unescape it to process the send email
-    String value = (String) ctx.get("ACTIVITY");
-    if (value != null) {
-      ctx.put("ACTIVITY", StringEscapeUtils.unescapeHtml4(value));
-    }
 
-    String subject = (String) ctx.get("SUBJECT");
-    if (subject != null && subject.length() > 0) {
-      ctx.put("SUBJECT", getExcerptSubject(subject));
-      return subjectElement.accept(SimpleElementVistior.instance().with(ctx)).out();
-    }
-    //
-    subject = subjectElement.accept(SimpleElementVistior.instance().with(ctx)).out();
-    return getExcerptSubject(subject);
-  }
-  
   /**
-   * Get the excerpt subject of notification mail from origin string
-   *  - Just contains plain text
-   *  - Limit number of characters
+   * Get the excerpt subject of notification mail from origin string - Just
+   * contains plain text - Limit number of characters
+   * 
    * @param subject the origin string
    * @return the excerpt of subject
    * @since 4.1.x
@@ -191,69 +126,42 @@ public class TemplateUtils {
 
     return newSubject;
   }
-  
+
   /**
    * Clean all HTML tags on string
-   *  
+   * 
    * @param str the origin string
    * @return The string has not contain HTML tags.
    * @since 4.1.x
    */
   public static String cleanHtmlTags(String str) {
     //
-    if (str == null || str.trim().length() == 0) {
+    if (StringUtils.isBlank(str)) {
       return "";
-    }
-    // clean multi-lines
-    String newSubject = StringUtils.replace(str, "\n", " ");
-    // clean script
-    newSubject = SCRIPT_REMOVE_PATTERN.matcher(newSubject).replaceAll("");
-    // clean tags HTML
-    newSubject = TAGS_REMOVE_PATTERN.matcher(newSubject).replaceAll(" ");
-    return newSubject.replaceAll("\\s+", " ").trim();
-  }
-
-  /**
-   * Render for digest template
-   * @param ctx
-   * @return
-   */
-  public static String processDigest(TemplateContext ctx) {
-    DigestTemplate digest = null;
-    String key = makeTemplateKey(DIGEST_TEMPLATE_KEY, ctx.getPluginId(), ctx.getLanguage());
-    if (cacheTemplate.containsKey(key)) {
-      digest = (DigestTemplate) cacheTemplate.get(key);
     } else {
-      PluginConfig templateConfig = getPluginConfig(ctx.getPluginId());
-      digest = NotificationUtils.getDigest(templateConfig, ctx.getPluginId(), ctx.getLanguage());
-      cacheTemplate.put(key, digest);
+      return Jsoup.parse(str).text();
     }
-    
-    return digest.accept(SimpleElementVistior.instance().with(ctx)).out();
   }
-  
-  private static String makeTemplateKey(String pattern, String pluginId, String language) {
-    return MessageFormat.format(pattern, pluginId, language);
-  }
-
 
   /**
    * Gets Plugin configuration for specified PluginId
+   * 
    * @param pluginId
    * @return
    */
-  private static PluginConfig getPluginConfig(String pluginId) {
+  public static PluginConfig getPluginConfig(String pluginId) {
     PluginConfig pluginConfig = NotificationContextImpl.cloneInstance().getPluginSettingService().getPluginConfig(pluginId);
-    
-    if(pluginConfig == null) {
+
+    if (pluginConfig == null) {
       throw new IllegalStateException("PluginConfig is NULL with plugId = " + pluginId);
     }
-    
+
     return pluginConfig;
   }
-  
+
   /**
    * Gets Resource Bundle value
+   * 
    * @param key
    * @param locale
    * @param resourcePath
@@ -264,20 +172,43 @@ public class TemplateUtils {
       return "";
     }
     if (locale == null || locale.getLanguage().isEmpty()) {
-      locale = Locale.ENGLISH;
+      locale = ResourceBundleService.DEFAULT_CROWDIN_LOCALE;
     }
-
     ResourceBundleService bundleService = CommonsUtils.getService(ResourceBundleService.class);
     ResourceBundle res = bundleService.getResourceBundle(resourcePath, locale);
-    
-    if (res == null || res.containsKey(key) == false) {
+    if (res != null && res.containsKey(key)) {
+      return res.getString(key);
+    } else {
       LOG.warn("Resource Bundle key not found. " + key + " in source path: " + resourcePath);
       return key;
     }
-
-    return res.getString(key);
   }
-  
-  
+
+  /**
+   * Gets InputStream for groovy template
+   * 
+   * @param templatePath
+   * @return {@link InputStream} corresponding to relative or absolute template path
+   */
+  @SneakyThrows
+  public static InputStream getTemplateInputStream(String templatePath) {
+    ConfigurationManager configurationManager = CommonsUtils.getService(ConfigurationManager.class);
+    String uri = templatePath;
+    if (!templatePath.startsWith("war:")
+        && !templatePath.startsWith("jar:")
+        && !templatePath.startsWith("classpath:")) {
+      if (templatePath.startsWith("/")) {
+        templatePath = templatePath.substring(1);
+      }
+      uri = "war:/" + templatePath;
+      if (configurationManager.getURL(uri) == null) {
+        uri = "jar:/" + templatePath;
+        if (configurationManager.getURL(uri) == null) {
+          uri = "classpath:/" + templatePath;
+        }
+      }
+    }
+    return configurationManager.getInputStream(uri);
+  }
 
 }

--- a/commons-component-common/src/test/resources/conf/exo.commons.component.core-local-configuration.xml
+++ b/commons-component-common/src/test/resources/conf/exo.commons.component.core-local-configuration.xml
@@ -23,6 +23,10 @@
                xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
                xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
+  <component>
+    <type>org.exoplatform.commons.notification.template.TemplateContentTransformerService</type>
+  </component>
+
   <external-component-plugins>
     <target-component>org.exoplatform.commons.api.notification.service.setting.PluginContainer</target-component>
     <component-plugin>


### PR DESCRIPTION
This change will allow to extend Mail Template content processing in upper modules by changing the behavior from Utils class to a dedicated Service which can be extended/overridden in upper layers.