### PR TITLE
fix: The status of links in article/note should be recognized as visited and unvisited - MEED-9100 - Meeds-io/meeds#3312

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditor/skins/common/extendedRichContent.less
+++ b/commons-extension-webapp/src/main/webapp/ckeditor/skins/common/extendedRichContent.less
@@ -98,10 +98,6 @@
     }
   }
 
-  a {
-    color: @linkColor !important;
-  }
-
   ol, ul, dl {
     margin: @listMargin !important;
     padding: @listPadding !important;


### PR DESCRIPTION
Before this change, when add an article/note then add a link and a mention in its content then visit the link and the mentioned user, the is no difference of color between the visited and unvisited status of link and mention. To fix this problem, delete the style to apply on the <a> tag in order to take the css to apply to the platform. After this change, there is a difference between visited and unvisited link color then unvisited link color equal to #006EDB and visited link color equal to #9B589B.
Resolves https://github.com/Meeds-io/meeds/issues/3312