### PR TITLE
fix: Upgrade Hibernate to version 6.6 - Meeds-io/meeds#3365

### DIFF
--- a/commons-component-common/src/test/java/org/exoplatform/jpa/CommonsDAOJPAImplTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/jpa/CommonsDAOJPAImplTest.java
@@ -97,17 +97,27 @@ public class CommonsDAOJPAImplTest extends BaseCommonsTestCase {
 
   private void cleanDB() {
     settingsDAO.deleteAll();
+    restartTransaction();
     settingScopeDAO.deleteAll();
+    restartTransaction();
     settingContextDAO.deleteAll();
+    restartTransaction();
 
     mailParamsDAO.deleteAll();
+    restartTransaction();
     mailDigestDAO.deleteAll();
+    restartTransaction();
     mailNotifDAO.deleteAll();
+    restartTransaction();
 
     webParamsDAO.deleteAll();
+    restartTransaction();
     webUsersDAO.deleteAll();
+    restartTransaction();
     webNotifDAO.deleteAll();
+    restartTransaction();
 
     mailQueueDAO.deleteAll();
+    restartTransaction();
   }
 }

--- a/commons-component-common/src/test/java/org/exoplatform/jpa/notifications/email/dao/MailDigestDAOTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/jpa/notifications/email/dao/MailDigestDAOTest.java
@@ -78,6 +78,7 @@ public class MailDigestDAOTest extends CommonsDAOJPAImplTest {
     //when
     context = NotificationContextImpl.cloneInstance();
     context.append(NotificationJob.JOB_WEEKLY, true);
+    restartTransaction();
     notificationDataStorage.removeMessageAfterSent(context);
     EntityManagerHolder.get().clear();
     mailNotifEntity1 = mailNotifDAO.find(mailNotifEntity1.getId());

--- a/commons-component-common/src/test/java/org/exoplatform/jpa/notifications/email/impl/JPANotificationServiceTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/jpa/notifications/email/impl/JPANotificationServiceTest.java
@@ -40,8 +40,11 @@ public class JPANotificationServiceTest extends BaseTest {
 
   @Override
   public void tearDown() throws Exception {
+    restartTransaction();
     mailParamDAO.deleteAll();
+    restartTransaction();
     mailDigestDAO.deleteAll();
+    restartTransaction();
     mailNotifDAO.deleteAll();
     super.tearDown();
   }
@@ -212,6 +215,7 @@ public class JPANotificationServiceTest extends BaseTest {
     assertEquals(1, list.size());
 
     context.append(NotificationJob.JOB_DAILY, true);
+    restartTransaction();
     notificationDataStorage.removeMessageAfterSent(context);
 
     context = NotificationContextImpl.cloneInstance();


### PR DESCRIPTION
This change will upgrade Hibernate to version 6.6 which introduced a bug fix (as explained in https://discourse.hibernate.org/t/instance-save-transient-before/10293/2) which makes some operations buggy when made in the same transaction. This change ensures to split operations, each in a transaction apart, to not hit such a problem.