### PR TITLE
feat: Allow to define default choice for a notification channel - MEED-9304

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/UserSetting.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/model/UserSetting.java
@@ -54,6 +54,8 @@ public class UserSetting {
 
   private Map<String, List<String>> channelPlugins;
 
+  private Map<String, Boolean> channelDefaultValue;
+
   private List<String>              dailyPlugins;
 
   private List<String>              weeklyPlugins;
@@ -67,6 +69,7 @@ public class UserSetting {
   public UserSetting() {
     this.channelActives = newSet(null);
     this.channelPlugins = newMap(null);
+    this.channelDefaultValue = new HashMap<>();
     //
     this.dailyPlugins = newList(null);
     this.weeklyPlugins = newList(null);
@@ -86,6 +89,18 @@ public class UserSetting {
     this.lastReadDate = lastReadDate;
   }
 
+  public void setChannelDefaultValueActive(String channelId, boolean value) {
+    if (channelDefaultValue == null) {
+      channelDefaultValue = new HashMap<>();
+    }
+    channelDefaultValue.put(channelId,value);
+  }
+  public Map<String, Boolean> getChannelDefaultValue () {
+    if (channelDefaultValue == null) {
+      channelDefaultValue = new HashMap<>();
+    }
+    return channelDefaultValue;
+  }
   public Set<String> getChannelActives() {
     if (channelActives == null) {
       channelActives = newSet(null);
@@ -295,6 +310,9 @@ public class UserSetting {
     for (Entry<String, List<String>> entry : channelPlugins.entrySet()) {
       setting.setChannelPlugins(entry.getKey(), newList(entry.getValue()));
     }
+    for (Entry<String, Boolean> entry : channelDefaultValue.entrySet()) {
+      setting.setChannelDefaultValueActive(entry.getKey(), entry.getValue());
+    }
     setting.setUserId(userId);
     setting.setMutedSpaces(mutedSpaces);
     return setting;
@@ -354,4 +372,17 @@ public class UserSetting {
     return Collections.synchronizedSet(set == null ? new HashSet<>() : new HashSet<>(set));
   }
 
+  public void applyDefaultValues() {
+    Set<String> currentActiveChannel = newSet(channelActives);
+    currentActiveChannel.forEach(channelId -> {
+      if (channelDefaultValue.containsKey(channelId)) {
+        boolean defaultValue = channelDefaultValue.get(channelId);
+        if (defaultValue) {
+          setChannelActive(channelId);
+        } else {
+          removeChannelActive(channelId);
+        }
+      }
+    });
+  }
 }

--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/service/setting/PluginSettingService.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/service/setting/PluginSettingService.java
@@ -72,6 +72,22 @@ public interface PluginSettingService {
   void saveChannelStatus(String channelId, boolean enable);
 
   /**
+   * Saves a default value for a given Channel
+   *
+   * @param channelId Channel identifier
+   * @param enable status whether enabled or not
+   */
+  void saveChannelDefaultValue(String channelId, boolean enable);
+
+  /**
+   * Get notification channel default value
+   *
+   * @param channelId Channel identifier
+   * @return true is active by default else inactive
+   */
+  boolean getDefaultChannelValue(String channelId);
+
+  /**
    * Saves email notification sender settings
    * 
    * @param name Company name

--- a/commons-component-common/src/main/java/org/exoplatform/settings/jpa/JPAPluginSettingServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/settings/jpa/JPAPluginSettingServiceImpl.java
@@ -64,6 +64,7 @@ public class JPAPluginSettingServiceImpl extends AbstractService implements Plug
   private static final Context       CHANNEL_CONTEXT                      = Context.GLOBAL.id("NotificationChannelSetting");
 
   private static final Scope         CHANNEL_SCOPE                        = Scope.APPLICATION.id("NotificationChannelSetting");
+  private static final Scope         CHANNEL_DEFAULT_VALUE_SCOPE                        = Scope.APPLICATION.id("NotificationChannelSettingDefaultValue");
 
   private static final String        NAME_SPACES                          = "exo:";
 
@@ -188,6 +189,16 @@ public class JPAPluginSettingServiceImpl extends AbstractService implements Plug
   }
 
   @Override
+  public void saveChannelDefaultValue(String channelId, boolean enable) {
+    settingService.set(CHANNEL_CONTEXT, CHANNEL_DEFAULT_VALUE_SCOPE, channelId, SettingValue.create(String.valueOf(enable)));
+    try {
+      listenerService.broadcast(NOTIFICATION_CHANNEL_STATUS_MODIFIED, channelId, null);
+    } catch (Exception e) {
+      LOG.warn("Error broadcasting channel status modification", e);
+    }
+  }
+
+  @Override
   public void saveEmailSender(String name, String email) {
     if (!NotificationUtils.isValidNotificationSenderName(name)) {
       throw new IllegalArgumentException("invalidSenderName");
@@ -219,6 +230,12 @@ public class JPAPluginSettingServiceImpl extends AbstractService implements Plug
   public boolean isChannelActive(String channelId) {
     SettingValue<?> activeSettingValue = settingService.get(CHANNEL_CONTEXT, CHANNEL_SCOPE, channelId);
     return activeSettingValue == null || activeSettingValue.getValue() == null || StringUtils.equals(activeSettingValue.getValue().toString(), "true");
+  }
+
+  @Override
+  public boolean getDefaultChannelValue(String channelId) {
+    SettingValue<?> channelDefaultValue = settingService.get(CHANNEL_CONTEXT, CHANNEL_DEFAULT_VALUE_SCOPE, channelId);
+    return channelDefaultValue == null || channelDefaultValue.getValue() == null || StringUtils.equals(channelDefaultValue.getValue().toString(), "true");
   }
 
   @Override

--- a/commons-component-common/src/main/java/org/exoplatform/settings/jpa/JPAUserSettingServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/settings/jpa/JPAUserSettingServiceImpl.java
@@ -167,6 +167,7 @@ public class JPAUserSettingServiceImpl extends AbstractService implements UserSe
     UserSetting userSettings = getDefaultSettings();
     userSettings.setUserId(userId);
     userSettings.setEnabled(isUserEnabled(userId));
+    userSettings.applyDefaultValues();
 
     Map<Scope, Map<String, SettingValue<String>>> userNotificationSettings = settingService.getSettingsByContext(USER.id(userId));
     if (userNotificationSettings == null || userNotificationSettings.isEmpty()) {
@@ -257,17 +258,13 @@ public class JPAUserSettingServiceImpl extends AbstractService implements UserSe
   public UserSetting getDefaultSettings() { // NOSONAR
     if (defaultSetting == null || PropertyManager.isDevelopping()) {
       defaultSetting = UserSetting.getInstance();
-      List<String> activeChannels = getDefaultSettingActiveChannels();
-      if (CollectionUtils.isEmpty(activeChannels)) {
         for (AbstractChannel channel : channelManager.getChannels()) {
           if (pluginSettingService.isChannelActive(channel.getId())) {
             defaultSetting.setChannelActive(channel.getId());
           }
+          defaultSetting.setChannelDefaultValueActive(channel.getId(),pluginSettingService.getDefaultChannelValue(channel.getId()));
         }
-      } else {
-        defaultSetting.getChannelActives().addAll(activeChannels);
-      }
-      //
+
       List<PluginInfo> plugins = pluginSettingService.getAllPlugins();
       for (PluginInfo pluginInfo : plugins) {
         List<String> pluginChannels = pluginSettingService.getPluginChannels(pluginInfo.getType());
@@ -380,12 +377,6 @@ public class JPAUserSettingServiceImpl extends AbstractService implements UserSe
       return NotificationUtils.stringToSet(getValues(value));
     }
     return defaultValue;
-  }
-
-  private List<String> getDefaultSettingActiveChannels() {
-    String activeChannels = System.getProperty("exo.notification.channels", "");
-    List<String> activeChannelsList = activeChannels.isEmpty() ? Collections.emptyList() : Arrays.asList(activeChannels.split(","));
-    return activeChannelsList.stream().filter(channelId -> pluginSettingService.isChannelActive(channelId)).toList();
   }
 
   private void fillDefaultSettingsOfUser(String username) {

--- a/commons-component-common/src/test/java/org/exoplatform/jpa/settings/impl/JPAUserSettingServiceTest.java
+++ b/commons-component-common/src/test/java/org/exoplatform/jpa/settings/impl/JPAUserSettingServiceTest.java
@@ -244,4 +244,24 @@ public class JPAUserSettingServiceTest extends BaseTest {
     model.setWeeklyPlugins(weekly);
     return model;
   }
+
+  public void testChannelDefaultValue() throws Exception {
+    String username = "testChannelDefaultValue";
+    User user = new UserImpl(username);
+    organizationService.getUserHandler().createUser(user, false);
+
+    UserSetting userSetting = userSettingService.get(username);
+    assertNotNull(userSetting);
+
+    //set channel default value to false for users
+    pluginSettingServiceImpl.saveChannelDefaultValue(CHANNEL_ID, false);
+
+    //channel is still active
+    assertTrue(pluginSettingServiceImpl.isChannelActive(CHANNEL_ID));
+
+    //user setting is still default settings
+    userSetting = userSettingService.get(username);
+    Set<String> channelActives = userSetting.getChannelActives();
+    assertFalse(channelActives.contains(CHANNEL_ID));
+  }
 }


### PR DESCRIPTION
Before this fix, there is no possibility to let a notification channel activated (aka. activable by all users) but deactivated by default This commit add an option to set default value for a channel. In addition, it removes the property exo.notification.channels which create problems to activate/deactivate channels

Resolves meeds-io/meeds#3409

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
