### PR TITLE
fix: can't add content after media embed - MEED-9397 - meeds-io/meeds#3454.

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/embedsemantic/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/embedsemantic/plugin.js
@@ -59,6 +59,7 @@
 									// undid/copied sth to fast) the content will be loaded on the next initialization.
 									that.setData( 'loadOnReady', false );
 									editor.fire( 'updateSnapshot' );
+                                    ensureFollowingBlock( that );
 								}
 							} );
 						}
@@ -117,7 +118,26 @@
 					dtd[ name ].oembed = 1;
 				}
 			}
-		}
+		},
+        
+	    ensureFollowingBlock: function( widget ) {
+            let editor = widget.editor,
+                element = widget.element,
+                next = element.getNext();
+            if ( !next || next.type !== CKEDITOR.NODE_ELEMENT || next.getName() === 'br' || editor.blockless ) {
+                let filler = editor.document.createElement( editor.config.autoParagraph || 'p' );
+                filler.setHtml( CKEDITOR.env.needsBrFiller ? '<br />' : '&nbsp;' );
+                element.insertAfter( filler );
+                if ( editor.getSelection().getSelectedElement() === element ) {
+                    editor.getSelection().selectElement( filler );
+                    let range = editor.getSelection().getRanges()[ 0 ];
+                    range.selectNodeContents( filler );
+                    range.collapse( true );
+                    editor.getSelection().selectRanges( [ range ] );
+                }
+                editor.fire( 'saveSnapshot' );
+            }
+        }
 	} );
 
 } )();


### PR DESCRIPTION
before this change, when create/update a notes page/news article and add media embed url and delete its below following line then try to add a line under the video afterwards, It isn't possible to add any line below the embed media. To fix this problem, add an editable block when the widget is inserted into the document. After this change, even if the line below the media embed was deleted, it is possible to add content under it.
