### PR TITLE
fix: can't add content after media embed - MEED-9397 - meeds-io/meeds#3454.

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/embedsemantic/lang/en.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/embedsemantic/lang/en.js
@@ -1,0 +1,3 @@
+CKEDITOR.plugins.setLang( 'embedsemantic', 'en', {
+	'button':'Add a line below'
+} );

--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/embedsemantic/lang/fr.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/embedsemantic/lang/fr.js
@@ -1,0 +1,3 @@
+CKEDITOR.plugins.setLang( 'embedsemantic', 'fr', {
+	'button':'Ajouter une ligne en dessous'
+} );

--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/embedsemantic/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/embedsemantic/plugin.js
@@ -7,6 +7,7 @@
 	'use strict';
 
 	CKEDITOR.plugins.add( 'embedsemantic', {
+		lang: ['en','fr'],
 		icons: 'embedsemantic', // %REMOVE_LINE_CORE%
 		hidpi: true, // %REMOVE_LINE_CORE%
 		requires: 'embedbase',
@@ -113,7 +114,7 @@
 
 					let btn = document.createElement('button');
 					btn.textContent = '↵';
-					btn.title = 'Ajouter une ligne en dessous';
+					btn.title = editor.lang.embedsemantic.button;
 					btn.className = 'cke-embed-add-line-btn';
 					Object.assign(btn.style, {
 						position: 'absolute',
@@ -153,21 +154,16 @@
 					btn.addEventListener('click', function(e) {
 						e.preventDefault();
 						e.stopPropagation();
-
 						let wrapperEl = widget.wrapper;
 						if (!wrapperEl) return;
-
-						let next = wrapperEl.getNext();
-						if (!next || next.getName() !== 'p') {
-							let newParagraph = editor.document.createElement('p');
-							newParagraph.setHtml('<br>'); // Ligne vide <br>
-							wrapperEl.insertAfter(newParagraph);
-							let range = editor.createRange();
-							range.moveToElementEditStart(newParagraph);
-							editor.getSelection().selectRanges([range]);
-							editor.focus();
-						}
-
+						let parent = wrapperEl.getParent();
+						let newParagraph = editor.document.createElement('p');
+						newParagraph.setHtml('<br>');
+						parent.append(newParagraph);
+						let range = editor.createRange();
+						range.moveToElementEditStart(newParagraph);
+						editor.getSelection().selectRanges([range]);
+						editor.focus();
 						editor.fire('saveSnapshot');
 						toggleAddLineButton();
 					});


### PR DESCRIPTION
before this change, when create/update a notes page/news article and add media embed url and delete its below following line then try to add a line under the video afterwards, It isn't possible to add any line below the embed media. To fix this problem, add a button, displayed when there is not a line after the widget, to add a line after the media embed. After this change, even if the line below the media embed was deleted, it is possible to add content under it.