### PR TITLE
feat: Allow to convert String JPA Value to Map

### DIFF
--- a/commons-component-common/src/main/java/org/exoplatform/commons/utils/StringMapConverter.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/utils/StringMapConverter.java
@@ -1,0 +1,53 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2025 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.commons.utils;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.StringUtils;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class StringMapConverter implements AttributeConverter<Map<String, String>, String> {
+
+  private static final String DELIMITER = "\n";
+
+  @Override
+  public String convertToDatabaseColumn(Map<String, String> attributes) {
+    return attributes
+        != null ?
+                StringUtils.join(attributes.entrySet().stream().map(e -> "%s=%s".formatted(e.getKey(), e.getValue())).toList(),
+                                 DELIMITER) :
+                null;
+  }
+
+  @Override
+  public Map<String, String> convertToEntityAttribute(String dbData) {
+    return dbData != null ? Arrays.stream(dbData.split(DELIMITER))
+                                  .filter(StringUtils::isNotBlank)
+                                  .collect(Collectors.toMap(v -> v.substring(0, v.indexOf("=")),
+                                                            v -> v.substring(v.indexOf("=") + 1))) :
+                          null;
+  }
+
+}


### PR DESCRIPTION
This change will allow to use a specific converters for DB Fields which will be parsed as a Java Map. In most cases, we will need a dedicated Table, but for simple properties Fields, it can be parsed as a single String in order to improve DB querying performances.