### PR TITLE
fix: Count viewers of a post even if no unread notification - MEED-10363 - Meeds-io/meeds#4166

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/lifecycle/DefaultLifecycle.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/lifecycle/DefaultLifecycle.java
@@ -44,7 +44,7 @@ public final class DefaultLifecycle extends AbstractNotificationLifecycle {
     for (String userId : userIds) {
       UserSetting userSetting = userService.get(userId);
       if (!userSetting.isEnabled()
-          || !userSetting.isChannelGloballyActive(channelId)
+          || (!userSetting.isChannelGloballyActive(channelId) && !channelId.equals("SPACE_WEB_CHANNEL"))
           || !userSetting.isActive(channelId, pluginId)
           || (userSetting.isSpaceMuted(notification.getSpaceId()) && pluginConfig.isMutable())) {
         continue;


### PR DESCRIPTION
Before this change, when access the space after the post has been added and unread notif channel has been deactivated then reading the post does not count in the views number, it could make the views number not equal to the factual number of readers. To fix this problem, correct the validatePropertySettingType condition. After this change, the activity stream will retrieve unread activity metadata even if the spaceWebChannelStatus notification is disabled. However, the unread activity badge will not be displayed as long as spaceWebChannelStatus is set to false, which has already been added to the eXo.env.portal.spaceWebChannelStatus property. Additionally, the unread activity badge is marked as read when eXo.env.portal.spaceWebChannelStatus is false and isUnread is true.