### PR TITLE
fix: Tag suggestor does not open automatically with the tag icon - EXO-87164

### DIFF
--- a/commons-extension-webapp/src/main/webapp/eXoPlugins/tagSuggester/plugin.js
+++ b/commons-extension-webapp/src/main/webapp/eXoPlugins/tagSuggester/plugin.js
@@ -37,6 +37,13 @@ require(['SHARED/jquery', 'SHARED/tagSuggester'],function($) {
       // Define the function that will be fired when the command is executed.
         exec: function( editor ) {
           editor.insertText('#');
+          setTimeout(() => {
+            const editable = editor.editable?.() || editor.element;
+            const $editable = $(editable.$ || editable);
+            $editable.trigger('input').trigger('keyup').trigger('focus');
+            const atwhoData = $editable.data('atwho');
+            atwhoData?.['#']?.controller?.view?.show();
+          }, 50);
           document.dispatchEvent(new CustomEvent('editor-option-added', {detail: 'useHash'}));
         }
       });


### PR DESCRIPTION
Prior to this change, clicking the tag icon only inserted a hashtag and did not open the tag suggester. This change updates the tag suggester plugin to automatically open the suggester when the tag icon is clicked.