### PR TITLE
fix: prevent selection from being blocked by content link icon - EXO-87169

### DIFF
--- a/commons-extension-webapp/src/main/webapp/ckeditorCustom/contents.less
+++ b/commons-extension-webapp/src/main/webapp/ckeditorCustom/contents.less
@@ -274,3 +274,7 @@ a > img {
 .text-center {
   text-align: center;
 }
+
+.content-link i {
+  -webkit-user-select: text !important;
+}


### PR DESCRIPTION
Prior to this change, when editing notes/news and attempting to select a line containing a content link, the selection stopped at the content link icon and did not allow selecting the full line. This change ensures that selection is no longer blocked by the content link icon.