### PR TITLE
feat: Allow to updating an existing Web Notification parameters without marking it as read - EXO-87664

### DIFF
--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/service/WebNotificationService.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/service/WebNotificationService.java
@@ -52,6 +52,14 @@ public interface WebNotificationService {
   void update(NotificationInfo notification, boolean moveTop);
 
   /**
+   * Updates Notification Owner Parameters
+   * 
+   * @param notificationId the notification id
+   * @param ownerParameters parameters to save for the notification
+   */
+  void updateNotificationParameters(String notificationId, Map<String, String> ownerParameters);
+
+  /**
    * Get the notificationInfo for the provided id
    *
    *

--- a/commons-api/src/main/java/org/exoplatform/commons/api/notification/service/storage/WebNotificationStorage.java
+++ b/commons-api/src/main/java/org/exoplatform/commons/api/notification/service/storage/WebNotificationStorage.java
@@ -55,6 +55,16 @@ public interface WebNotificationStorage {
   void update(NotificationInfo notification, boolean moveTop);
 
   /**
+   * Update an existing notification notification parameters
+   * 
+   * @param notificationId the Notification Id
+   * @param ownerParameters parameters to save
+   */
+  default void updateNotificationParameters(String notificationId, Map<String, String> ownerParameters) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Marks the notification to be read by the userId
    * 
    * @param notificationId the Notification Id

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/jpa/web/JPAWebNotificationStorage.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/jpa/web/JPAWebNotificationStorage.java
@@ -254,6 +254,14 @@ public class JPAWebNotificationStorage implements WebNotificationStorage {
   }
 
   @Override
+  public void updateNotificationParameters(String notificationId, Map<String, String> ownerParameters) {
+    WebUsersEntity webUsersEntity = webUsersDAO.find(parseNotificationId(notificationId));
+    if (webUsersEntity != null) {
+      updateNotificationParameters(webUsersEntity.getNotification(), ownerParameters, false);
+    }
+  }
+
+  @Override
   @ExoTransactional
   public int getNumberOnBadge(String userId) {
     return webUsersDAO.getNumberOnBadge(userId);

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/WebNotificationServiceImpl.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/WebNotificationServiceImpl.java
@@ -82,6 +82,11 @@ public class WebNotificationServiceImpl implements WebNotificationService {
   }
 
   @Override
+  public void updateNotificationParameters(String notificationId, Map<String, String> ownerParameters) {
+    storage.updateNotificationParameters(notificationId, ownerParameters);
+  }
+
+  @Override
   public NotificationInfo getUnreadNotification(String pluginId, String activityId, String userId) {
     return storage.getUnreadNotification(pluginId, activityId, userId);
   }

--- a/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/storage/cache/CachedWebNotificationStorage.java
+++ b/commons-component-common/src/main/java/org/exoplatform/commons/notification/impl/service/storage/cache/CachedWebNotificationStorage.java
@@ -94,6 +94,12 @@ public class CachedWebNotificationStorage implements WebNotificationStorage {
   }
 
   @Override
+  public void updateNotificationParameters(String notificationId, Map<String, String> ownerParameters) {
+    storage.updateNotificationParameters(notificationId, ownerParameters);
+    futureWebNotificationCache.remove(WebNotifInfoCacheKey.key(notificationId));
+  }
+
+  @Override
   public void markRead(String notificationId) {
     storage.markRead(notificationId);
     updateRead(notificationId);


### PR DESCRIPTION
Prior to this change, any Update on Web notification results to mark it as read. This change doesn't introduce a breaking change but allows to update the Web Notification parameters through a dedicated API call.